### PR TITLE
change FilterByPipe name to match pipe naming conventions

### DIFF
--- a/src/collection/filter-by.pipe.ts
+++ b/src/collection/filter-by.pipe.ts
@@ -3,7 +3,7 @@ import { toArray, isArray, isString, isNumber, isUndefined } from '../utils/util
 import { Parse } from '../utils/parse';
 
 @Pipe({
-  name: 'filter-by'
+  name: 'filterBy'
 })
 export class FilterByPipe implements PipeTransform {
   private $parse: Function;


### PR DESCRIPTION
I was trying to use the 'filter-by' pipe in my angular2 app and it was complaining about the 'filter-by' naming. I changed the name to match more of the naming convention for pipes to filterBy. Thanks for making this!