### PR TITLE
Add clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+Language:                                   JavaScript
+BasedOnStyle:                               Google
+ColumnLimit:                                100

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "ngc": "node_modules/.bin/ngc -p tsconfig.json",
     "build": "npm run tsc && npm run rollup",
     "rollup": "./node_modules/.bin/rollup -c -o dist/ng-pipes.umd.js",
-    "postrollup": "./node_modules/.bin/uglifyjs ./dist/ng-pipes.umd.js > ./dist/ng-pipes.umd.min.js"
+    "postrollup": "./node_modules/.bin/uglifyjs ./dist/ng-pipes.umd.js > ./dist/ng-pipes.umd.min.js",
+    "format": "./node_modules/.bin/clang-format --glob=\"@(src|test)/**/*.ts\" -i"
   },
   "author": "Ariel Mashraki",
   "repository": {
@@ -45,6 +46,7 @@
     "@angular/platform-server": "^2.3.0",
     "@types/core-js": "^0.9.34",
     "@types/jasmine": "^2.5.37",
+    "clang-format": "^1.0.46",
     "core-js": "^2.4.1",
     "gulp": "^3.9.1",
     "gulp-clean": "^0.3.2",

--- a/src/boolean/index.ts
+++ b/src/boolean/index.ts
@@ -1,6 +1,6 @@
-import { NgModule } from '@angular/core';
+import {NgModule} from '@angular/core';
 
-import { IsNullPipe } from './is-null.pipe';
+import {IsNullPipe} from './is-null.pipe';
 
 export * from './is-null.pipe';
 
@@ -12,4 +12,5 @@ export * from './is-null.pipe';
     IsNullPipe,
   ]
 })
-export class BooleanPipesModule { }
+export class BooleanPipesModule {
+}

--- a/src/boolean/is-null.pipe.ts
+++ b/src/boolean/is-null.pipe.ts
@@ -1,9 +1,7 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isNull } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
+import {isNull} from '../utils/utils';
 
-@Pipe({
-  name: 'isNull'
-})
+@Pipe({name: 'isNull'})
 export class IsNullPipe implements PipeTransform {
   transform(input: any): boolean {
     return isNull(input);

--- a/src/collection/after-where.pipe.ts
+++ b/src/collection/after-where.pipe.ts
@@ -1,11 +1,10 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, objectContains } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'afterWhere'
-})
+import {isArray, objectContains, toArray} from '../utils/utils';
+
+@Pipe({name: 'afterWhere'})
 export class AfterWherePipe implements PipeTransform {
-  transform(collection: any, object: { [key: string]: any }): Array<any> {
+  transform(collection: any, object: {[key: string]: any}): Array<any> {
     if (!isArray(collection)) {
       collection = toArray(collection);
     }
@@ -13,7 +12,8 @@ export class AfterWherePipe implements PipeTransform {
       return collection;
     }
 
-    let index = collection.map((e: { [key: string]: any }) => objectContains(object, e)).indexOf(true);
+    let index =
+        collection.map((e: {[key: string]: any}) => objectContains(object, e)).indexOf(true);
 
     return collection.slice(index == -1 ? 0 : index);
   }

--- a/src/collection/after.pipe.ts
+++ b/src/collection/after.pipe.ts
@@ -1,9 +1,8 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'after'
-})
+import {isArray, toArray} from '../utils/utils';
+
+@Pipe({name: 'after'})
 export class AfterPipe implements PipeTransform {
   transform(collection: any, count: number = 0): Array<any> {
     if (!isArray(collection)) {

--- a/src/collection/before-where.pipe.ts
+++ b/src/collection/before-where.pipe.ts
@@ -1,11 +1,10 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, objectContains } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'beforeWhere'
-})
+import {isArray, objectContains, toArray} from '../utils/utils';
+
+@Pipe({name: 'beforeWhere'})
 export class BeforeWherePipe implements PipeTransform {
-  transform(collection: any, object: { [key: string]: any }): Array<any> {
+  transform(collection: any, object: {[key: string]: any}): Array<any> {
     if (!isArray(collection)) {
       collection = toArray(collection);
     }
@@ -13,7 +12,8 @@ export class BeforeWherePipe implements PipeTransform {
       return collection;
     }
 
-    let index = collection.map((e: { [key: string]: any }) => objectContains(object, e)).indexOf(true);
+    let index =
+        collection.map((e: {[key: string]: any}) => objectContains(object, e)).indexOf(true);
 
     return collection.slice(0, index == -1 ? collection.length : index + 1);
   }

--- a/src/collection/before.pipe.ts
+++ b/src/collection/before.pipe.ts
@@ -1,9 +1,8 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'before'
-})
+import {isArray, toArray} from '../utils/utils';
+
+@Pipe({name: 'before'})
 export class BeforePipe implements PipeTransform {
   transform(collection: any, count: number = 1): Array<any> {
     if (!isArray(collection)) {

--- a/src/collection/chunk-by.pipe.ts
+++ b/src/collection/chunk-by.pipe.ts
@@ -1,25 +1,22 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isUndefined } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
+import {isUndefined} from '../utils/utils';
 
-@Pipe({
-  name: 'chunkBy'
-})
+@Pipe({name: 'chunkBy'})
 export class ChunkByPipe implements PipeTransform {
   transform(array: Array<any>, n: number, fillVal?: any): Array<any> {
-
     function fill(n: number, val: any): Array<any> {
       let ret: Array<any> = [];
       while (n--) ret[n] = val;
       return ret;
     }
 
-    return array.map((el, i, self) => {
-      i = i * n;
-      el = self.slice(i, i + n);
-      return !isUndefined(fillVal) && el.length < n
-        ? el.concat(fill(n - el.length, fillVal))
-        : el;
-    })
-      .slice(0, Math.ceil(array.length / n));
+    return array
+        .map((el, i, self) => {
+          i = i * n;
+          el = self.slice(i, i + n);
+          return !isUndefined(fillVal) && el.length < n ? el.concat(fill(n - el.length, fillVal)) :
+                                                          el;
+        })
+        .slice(0, Math.ceil(array.length / n));
   }
 }

--- a/src/collection/concat.pipe.ts
+++ b/src/collection/concat.pipe.ts
@@ -1,9 +1,8 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'concat'
-})
+import {isArray, toArray} from '../utils/utils';
+
+@Pipe({name: 'concat'})
 export class ConcatPipe implements PipeTransform {
   transform(collection: any, joined: any): Array<any> {
     if (!isArray(collection)) {

--- a/src/collection/contains.pipe.ts
+++ b/src/collection/contains.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isArray, toArray, isString, isFunction, isObject } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'contains'
-})
+import {Parse} from '../utils/parse';
+import {isArray, isFunction, isObject, isString, toArray} from '../utils/utils';
+
+@Pipe({name: 'contains'})
 export class ContainsPipe implements PipeTransform {
   private $parse: Function;
 
@@ -17,8 +16,9 @@ export class ContainsPipe implements PipeTransform {
       collection = toArray(collection);
     }
 
-    return collection.some((e: any) => isFunction(predicate) || (isString(predicate) && isObject(e))
-      ? this.$parse(predicate)(e)
-      : e === predicate);
+    return collection.some(
+        (e: any) => isFunction(predicate) || (isString(predicate) && isObject(e)) ?
+            this.$parse(predicate)(e) :
+            e === predicate);
   }
 }

--- a/src/collection/count-by.pipe.ts
+++ b/src/collection/count-by.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isArray, toArray } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'countBy'
-})
+import {Parse} from '../utils/parse';
+import {isArray, toArray} from '../utils/utils';
+
+@Pipe({name: 'countBy'})
 export class CountByPipe implements PipeTransform {
   private $parse: Function;
 
@@ -12,10 +11,8 @@ export class CountByPipe implements PipeTransform {
     this.$parse = Parse();
   }
 
-  transform(collection: any, predicate: any): { [key: string]: number } {
-    let result: { [key: string]: number } = {}
-      , getter = this.$parse(predicate)
-      ;
+  transform(collection: any, predicate: any): {[key: string]: number} {
+    let result: {[key: string]: number} = {}, getter = this.$parse(predicate);
     if (!isArray(collection)) {
       collection = toArray(collection);
     }

--- a/src/collection/defaults.pipe.ts
+++ b/src/collection/defaults.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, isUndefined, deepKeys } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'defaults'
-})
+import {Parse} from '../utils/parse';
+import {deepKeys, isArray, isUndefined, toArray} from '../utils/utils';
+
+@Pipe({name: 'defaults'})
 export class DefaultsPipe implements PipeTransform {
   private $parse: Function;
 
@@ -12,7 +11,7 @@ export class DefaultsPipe implements PipeTransform {
     this.$parse = Parse();
   }
 
-  transform(collection: any, defaults: { [key: string]: any }): Array<any> {
+  transform(collection: any, defaults: {[key: string]: any}): Array<any> {
     if (!isArray(collection)) {
       collection = toArray(collection);
     }
@@ -22,7 +21,7 @@ export class DefaultsPipe implements PipeTransform {
 
     let getters = deepKeys(defaults).map((key: string) => this.$parse(key));
 
-    collection.forEach((elm: { [key: string]: any }) => {
+    collection.forEach((elm: {[key: string]: any}) => {
       getters.forEach((getter: any) => {
         if (isUndefined(getter(elm))) {
           getter.assign(elm, getter(defaults));

--- a/src/collection/every.pipe.ts
+++ b/src/collection/every.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isArray, toArray, isString, isFunction, isObject } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'every'
-})
+import {Parse} from '../utils/parse';
+import {isArray, isFunction, isObject, isString, toArray} from '../utils/utils';
+
+@Pipe({name: 'every'})
 export class EveryPipe implements PipeTransform {
   private $parse: Function;
 
@@ -17,8 +16,9 @@ export class EveryPipe implements PipeTransform {
       collection = toArray(collection);
     }
 
-    return collection.every((e: any) => isFunction(predicate) || (isString(predicate) && isObject(e))
-      ? this.$parse(predicate)(e)
-      : e === predicate);
+    return collection.every(
+        (e: any) => isFunction(predicate) || (isString(predicate) && isObject(e)) ?
+            this.$parse(predicate)(e) :
+            e === predicate);
   }
 }

--- a/src/collection/filter-by.pipe.ts
+++ b/src/collection/filter-by.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, isString, isNumber, isUndefined } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'filterBy'
-})
+import {Parse} from '../utils/parse';
+import {isArray, isNumber, isString, isUndefined, toArray} from '../utils/utils';
+
+@Pipe({name: 'filterBy'})
 export class FilterByPipe implements PipeTransform {
   private $parse: Function;
 
@@ -12,14 +11,13 @@ export class FilterByPipe implements PipeTransform {
     this.$parse = Parse();
   }
 
-  transform(collection: any, properties: string[], search?: any, strict: boolean = false): Array<any> {
+  transform(collection: any, properties: string[], search?: any, strict: boolean = false):
+      Array<any> {
     if (!isArray(collection)) {
       collection = toArray(collection);
     }
 
-    search = isString(search) || isNumber(search)
-      ? String(search).toLowerCase()
-      : undefined;
+    search = isString(search) || isNumber(search) ? String(search).toLowerCase() : undefined;
 
     if (!isArray(collection) || isUndefined(search)) {
       return collection;
@@ -42,9 +40,7 @@ export class FilterByPipe implements PipeTransform {
           comparator = this.$parse(prop)(elm)
         } else {
           let propList = prop.replace(/\s+/g, '').split('+');
-          comparator = propList
-            .map((p: string) => this.$parse(p)(elm))
-            .join(' ');
+          comparator = propList.map((p: string) => this.$parse(p)(elm)).join(' ');
         }
 
         // TODO: boolean?
@@ -55,11 +51,8 @@ export class FilterByPipe implements PipeTransform {
         comparator = String(comparator).toLowerCase();
 
         // indentical or contains
-        return strict
-          ? comparator === search
-          : comparator.indexOf(search) != -1;
+        return strict ? comparator === search : comparator.indexOf(search) != -1;
       });
     });
-
   }
 }

--- a/src/collection/first.pipe.ts
+++ b/src/collection/first.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, getFirstMatches, isNumber } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'first'
-})
+import {Parse} from '../utils/parse';
+import {getFirstMatches, isArray, isNumber, toArray} from '../utils/utils';
+
+@Pipe({name: 'first'})
 export class FirstPipe implements PipeTransform {
   private $parse: Function;
 
@@ -17,11 +16,10 @@ export class FirstPipe implements PipeTransform {
       collection = toArray(collection);
     }
 
-    let n: number = isNumber(args[0]) ? args[0] : 1
-      , getter = !isNumber(args[0]) ? args[0] : !isNumber(args[1]) ? args[1] : undefined;
+    let n: number = isNumber(args[0]) ? args[0] : 1,
+           getter = !isNumber(args[0]) ? args[0] : !isNumber(args[1]) ? args[1] : undefined;
 
-    return args.length
-      ? getFirstMatches(collection, n, getter ? this.$parse(getter) : getter)
-      : collection[0];
+    return args.length ? getFirstMatches(collection, n, getter ? this.$parse(getter) : getter) :
+                         collection[0];
   }
 }

--- a/src/collection/flatten.pipe.ts
+++ b/src/collection/flatten.pipe.ts
@@ -1,11 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'flatten'
-})
+import {isArray, toArray} from '../utils/utils';
+
+@Pipe({name: 'flatten'})
 export class FlattenPipe implements PipeTransform {
-
   transform(collection: any, shallow: boolean = false): any[] {
     if (!isArray(collection)) {
       collection = toArray(collection);
@@ -14,13 +12,13 @@ export class FlattenPipe implements PipeTransform {
       return collection;
     }
 
-    return shallow
-      ? [].concat.apply([], collection)
-      : this.flatten(collection);
+    return shallow ? [].concat.apply([], collection) : this.flatten(collection);
   }
 
   private flatten(array: any[]): any[] {
-    return array.reduce((arr: any[], elm: any) => elm instanceof Array ?
-      arr.concat(this.flatten(elm)) : arr.concat(elm), []);
+    return array.reduce(
+        (arr: any[], elm: any) =>
+            elm instanceof Array ? arr.concat(this.flatten(elm)) : arr.concat(elm),
+        []);
   }
 }

--- a/src/collection/fuzzy-by.pipe.ts
+++ b/src/collection/fuzzy-by.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, isString, isUndefined, hasApproxPattern } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'fuzzyBy'
-})
+import {Parse} from '../utils/parse';
+import {hasApproxPattern, isArray, isString, isUndefined, toArray} from '../utils/utils';
+
+@Pipe({name: 'fuzzyBy'})
 export class FuzzyByPipe implements PipeTransform {
   private $parse: Function;
 
@@ -12,7 +11,8 @@ export class FuzzyByPipe implements PipeTransform {
     this.$parse = Parse();
   }
 
-  transform(collection: any, property: string, search?: any, csensitive: boolean = false): Array<any> {
+  transform(collection: any, property: string, search?: any, csensitive: boolean = false):
+      Array<any> {
     if (!isArray(collection)) {
       collection = toArray(collection);
     }

--- a/src/collection/fuzzy.pipe.ts
+++ b/src/collection/fuzzy.pipe.ts
@@ -1,11 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, isString, isUndefined, hasApproxPattern, isObject } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'fuzzy'
-})
+import {hasApproxPattern, isArray, isObject, isString, isUndefined, toArray} from '../utils/utils';
+
+@Pipe({name: 'fuzzy'})
 export class FuzzyPipe implements PipeTransform {
-
   transform(collection: any, search: string, csensitive: boolean = false): Array<any> {
     if (!isArray(collection)) {
       collection = toArray(collection);
@@ -30,7 +28,8 @@ export class FuzzyPipe implements PipeTransform {
     });
   }
 
-  private hasApproximateKey(object: { [key: string]: any }, search: string, csensitive: boolean = false): boolean {
+  private hasApproximateKey(
+      object: {[key: string]: any}, search: string, csensitive: boolean = false): boolean {
     return Object.keys(object).some((elm: string) => {
       let prop = object[elm];
       if (!isString(prop)) {

--- a/src/collection/group-by.pipe.ts
+++ b/src/collection/group-by.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, isUndefined } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'groupBy'
-})
+import {Parse} from '../utils/parse';
+import {isArray, isUndefined, toArray} from '../utils/utils';
+
+@Pipe({name: 'groupBy'})
 export class GroupByPipe implements PipeTransform {
   private $parse: Function;
 
@@ -12,14 +11,12 @@ export class GroupByPipe implements PipeTransform {
     this.$parse = Parse();
   }
 
-  transform(collection: any, prop: string): { [key: string]: Array<any> } {
+  transform(collection: any, prop: string): {[key: string]: Array<any>} {
     if (!isArray(collection)) {
       collection = toArray(collection);
     }
 
-    let result: { [key: string]: Array<any> } = {}
-      , getter = this.$parse(prop)
-      ;
+    let result: {[key: string]: Array<any>} = {}, getter = this.$parse(prop);
     collection.forEach((elm: any) => {
       let prop = getter(elm);
       if (isUndefined(result[prop])) {

--- a/src/collection/index.ts
+++ b/src/collection/index.ts
@@ -1,37 +1,37 @@
-import { NgModule } from '@angular/core';
+import {NgModule} from '@angular/core';
 
-import { AfterWherePipe } from './after-where.pipe';
-import { BeforeWherePipe } from './before-where.pipe';
-import { AfterPipe } from './after.pipe';
-import { BeforePipe } from './before.pipe';
-import { ChunkByPipe } from './chunk-by.pipe';
-import { ConcatPipe } from './concat.pipe';
-import { ContainsPipe } from './contains.pipe';
-import { CountByPipe } from './count-by.pipe';
-import { DefaultsPipe } from './defaults.pipe';
-import { EveryPipe } from './every.pipe';
-import { FilterByPipe } from './filter-by.pipe';
-import { FirstPipe } from './first.pipe';
-import { FlattenPipe } from './flatten.pipe';
-import { FuzzyByPipe } from './fuzzy-by.pipe';
-import { FuzzyPipe } from './fuzzy.pipe';
-import { GroupByPipe } from './group-by.pipe';
-import { IsEmptyPipe } from './is-empty.pipe';
-import { JoinPipe } from './join.pipe';
-import { LastPipe } from './last.pipe';
-import { MapPipe } from './map.pipe';
-import { OmitPipe } from './omit.pipe';
-import { PickPipe } from './pick.pipe';
-import { RangePipe } from './range.pipe';
-import { RemoveWithPipe } from './remove-with.pipe';
-import { RemovePipe } from './remove.pipe';
-import { ReversePipe } from './reverse.pipe';
-import { SearchFieldPipe } from './search-field.pipe';
-import { ToArrayPipe } from './to-array.pipe';
-import { UniqPipe } from './uniq.pipe';
-import { WherePipe } from './where.pipe';
-import { XORPipe } from './xor.pipe';
-import { OrderByPipe } from './order-by.pipe';
+import {AfterWherePipe} from './after-where.pipe';
+import {AfterPipe} from './after.pipe';
+import {BeforeWherePipe} from './before-where.pipe';
+import {BeforePipe} from './before.pipe';
+import {ChunkByPipe} from './chunk-by.pipe';
+import {ConcatPipe} from './concat.pipe';
+import {ContainsPipe} from './contains.pipe';
+import {CountByPipe} from './count-by.pipe';
+import {DefaultsPipe} from './defaults.pipe';
+import {EveryPipe} from './every.pipe';
+import {FilterByPipe} from './filter-by.pipe';
+import {FirstPipe} from './first.pipe';
+import {FlattenPipe} from './flatten.pipe';
+import {FuzzyByPipe} from './fuzzy-by.pipe';
+import {FuzzyPipe} from './fuzzy.pipe';
+import {GroupByPipe} from './group-by.pipe';
+import {IsEmptyPipe} from './is-empty.pipe';
+import {JoinPipe} from './join.pipe';
+import {LastPipe} from './last.pipe';
+import {MapPipe} from './map.pipe';
+import {OmitPipe} from './omit.pipe';
+import {OrderByPipe} from './order-by.pipe';
+import {PickPipe} from './pick.pipe';
+import {RangePipe} from './range.pipe';
+import {RemoveWithPipe} from './remove-with.pipe';
+import {RemovePipe} from './remove.pipe';
+import {ReversePipe} from './reverse.pipe';
+import {SearchFieldPipe} from './search-field.pipe';
+import {ToArrayPipe} from './to-array.pipe';
+import {UniqPipe} from './uniq.pipe';
+import {WherePipe} from './where.pipe';
+import {XORPipe} from './xor.pipe';
 
 export * from './after-where.pipe';
 export * from './before-where.pipe';
@@ -68,72 +68,21 @@ export * from './order-by.pipe';
 
 @NgModule({
   declarations: [
-    AfterWherePipe,
-    BeforeWherePipe,
-    AfterPipe,
-    BeforePipe,
-    ChunkByPipe,
-    ConcatPipe,
-    ContainsPipe,
-    CountByPipe,
-    DefaultsPipe,
-    EveryPipe,
-    FilterByPipe,
-    FirstPipe,
-    FlattenPipe,
-    FuzzyByPipe,
-    FuzzyPipe,
-    GroupByPipe,
-    IsEmptyPipe,
-    JoinPipe,
-    LastPipe,
-    MapPipe,
-    OmitPipe,
-    PickPipe,
-    RangePipe,
-    RemoveWithPipe,
-    ReversePipe,
-    SearchFieldPipe,
-    RemovePipe,
-    ToArrayPipe,
-    UniqPipe,
-    WherePipe,
-    XORPipe,
-    OrderByPipe,
+    AfterWherePipe, BeforeWherePipe, AfterPipe,    BeforePipe,  ChunkByPipe,  ConcatPipe,
+    ContainsPipe,   CountByPipe,     DefaultsPipe, EveryPipe,   FilterByPipe, FirstPipe,
+    FlattenPipe,    FuzzyByPipe,     FuzzyPipe,    GroupByPipe, IsEmptyPipe,  JoinPipe,
+    LastPipe,       MapPipe,         OmitPipe,     PickPipe,    RangePipe,    RemoveWithPipe,
+    ReversePipe,    SearchFieldPipe, RemovePipe,   ToArrayPipe, UniqPipe,     WherePipe,
+    XORPipe,        OrderByPipe,
   ],
   exports: [
-    AfterWherePipe,
-    BeforeWherePipe,
-    AfterPipe,
-    BeforePipe,
-    ChunkByPipe,
-    ConcatPipe,
-    ContainsPipe,
-    CountByPipe,
-    DefaultsPipe,
-    EveryPipe,
-    FilterByPipe,
-    FirstPipe,
-    FlattenPipe,
-    FuzzyByPipe,
-    FuzzyPipe,
-    GroupByPipe,
-    IsEmptyPipe,
-    JoinPipe,
-    LastPipe,
-    MapPipe,
-    OmitPipe,
-    PickPipe,
-    RangePipe,
-    RemoveWithPipe,
-    ReversePipe,
-    SearchFieldPipe,
-    RemovePipe,
-    ToArrayPipe,
-    UniqPipe,
-    WherePipe,
-    XORPipe,
-    OrderByPipe,
+    AfterWherePipe, BeforeWherePipe, AfterPipe,    BeforePipe,  ChunkByPipe,  ConcatPipe,
+    ContainsPipe,   CountByPipe,     DefaultsPipe, EveryPipe,   FilterByPipe, FirstPipe,
+    FlattenPipe,    FuzzyByPipe,     FuzzyPipe,    GroupByPipe, IsEmptyPipe,  JoinPipe,
+    LastPipe,       MapPipe,         OmitPipe,     PickPipe,    RangePipe,    RemoveWithPipe,
+    ReversePipe,    SearchFieldPipe, RemovePipe,   ToArrayPipe, UniqPipe,     WherePipe,
+    XORPipe,        OrderByPipe,
   ]
 })
-export class CollectionPipesModule { }
+export class CollectionPipesModule {
+}

--- a/src/collection/is-empty.pipe.ts
+++ b/src/collection/is-empty.pipe.ts
@@ -1,9 +1,8 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'isEmpty'
-})
+import {isArray, toArray} from '../utils/utils';
+
+@Pipe({name: 'isEmpty'})
 export class IsEmptyPipe implements PipeTransform {
   transform(collection: any): boolean {
     if (!isArray(collection)) {

--- a/src/collection/join.pipe.ts
+++ b/src/collection/join.pipe.ts
@@ -1,9 +1,8 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'join'
-})
+import {isArray, toArray} from '../utils/utils';
+
+@Pipe({name: 'join'})
 export class JoinPipe implements PipeTransform {
   transform(collection: any, delimiter: any = ' '): string {
     if (!isArray(collection)) {

--- a/src/collection/last.pipe.ts
+++ b/src/collection/last.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, getFirstMatches, isNumber } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'last'
-})
+import {Parse} from '../utils/parse';
+import {getFirstMatches, isArray, isNumber, toArray} from '../utils/utils';
+
+@Pipe({name: 'last'})
 export class LastPipe implements PipeTransform {
   private $parse: Function;
 
@@ -23,12 +22,13 @@ export class LastPipe implements PipeTransform {
 
     collection = collection.slice().reverse();
 
-    let n: number = isNumber(args[0]) ? args[0] : 1
-      , getter = !isNumber(args[0]) ? args[0] : !isNumber(args[1]) ? args[1] : undefined;
+    let n: number = isNumber(args[0]) ? args[0] : 1,
+           getter = !isNumber(args[0]) ? args[0] : !isNumber(args[1]) ? args[1] : undefined;
 
     return args.length
-      // send reversed collection as arguments, and reverse it back
-      ? getFirstMatches(collection, n, getter ? this.$parse(getter) : getter).reverse()
-      : collection[0];
+        // send reversed collection as arguments, and reverse it back
+        ?
+        getFirstMatches(collection, n, getter ? this.$parse(getter) : getter).reverse() :
+        collection[0];
   }
 }

--- a/src/collection/map.pipe.ts
+++ b/src/collection/map.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'map'
-})
+import {Parse} from '../utils/parse';
+import {isArray, toArray} from '../utils/utils';
+
+@Pipe({name: 'map'})
 export class MapPipe implements PipeTransform {
   private $parse: Function;
 

--- a/src/collection/omit.pipe.ts
+++ b/src/collection/omit.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'omit'
-})
+import {Parse} from '../utils/parse';
+import {isArray, toArray} from '../utils/utils';
+
+@Pipe({name: 'omit'})
 export class OmitPipe implements PipeTransform {
   private $parse: Function;
 

--- a/src/collection/order-by.pipe.ts
+++ b/src/collection/order-by.pipe.ts
@@ -1,9 +1,7 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
+import {Parse} from '../utils/parse';
 
-@Pipe({
-  name: 'orderBy'
-})
+@Pipe({name: 'orderBy'})
 export class OrderByPipe implements PipeTransform {
   private $parse: Function;
 
@@ -17,27 +15,23 @@ export class OrderByPipe implements PipeTransform {
     let predicates = attrs.map(pred => {
       let descending = pred.charAt(0) === '-' ? -1 : 1;
       pred = pred.replace(/^-/, '');
-      return {
-        getter: (o: any) => this.$parse(pred)(o),
-        descend: descending
-      };
+      return {getter: (o: any) => this.$parse(pred)(o), descend: descending};
     });
-    // schwartzian transform idiom implementation. aka: "decorate-sort-undecorate"
-    return array.map(item => {
-      return {
-        src: item,
-        compareValues: predicates.map(predicate => predicate.getter(item))
-      };
-    })
-      .sort((o1: any, o2: any) => {
-        let i = -1, result = 0;
-        while (++i < predicates.length) {
-          if (o1.compareValues[i] < o2.compareValues[i]) result = -1;
-          if (o1.compareValues[i] > o2.compareValues[i]) result = 1;
-          if (result *= predicates[i].descend) break;
-        }
-        return result;
-      })
-      .map(item => item.src);
+    // schwartzian transform idiom implementation. aka:
+    // "decorate-sort-undecorate"
+    return array
+        .map(item => {
+          return {src: item, compareValues: predicates.map(predicate => predicate.getter(item))};
+        })
+        .sort((o1: any, o2: any) => {
+          let i = -1, result = 0;
+          while (++i < predicates.length) {
+            if (o1.compareValues[i] < o2.compareValues[i]) result = -1;
+            if (o1.compareValues[i] > o2.compareValues[i]) result = 1;
+            if (result *= predicates[i].descend) break;
+          }
+          return result;
+        })
+        .map(item => item.src);
   }
 }

--- a/src/collection/pick.pipe.ts
+++ b/src/collection/pick.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'pick'
-})
+import {Parse} from '../utils/parse';
+import {isArray, toArray} from '../utils/utils';
+
+@Pipe({name: 'pick'})
 export class PickPipe implements PipeTransform {
   private $parse: Function;
 

--- a/src/collection/range.pipe.ts
+++ b/src/collection/range.pipe.ts
@@ -1,11 +1,11 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isFunction } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
+import {isFunction} from '../utils/utils';
 
-@Pipe({
-  name: 'range'
-})
+@Pipe({name: 'range'})
 export class RangePipe implements PipeTransform {
-  transform(input: number[], total: number = 0, start: number = 0, increment: number = 1, cb?: Function): any {
+  transform(
+      input: number[], total: number = 0, start: number = 0, increment: number = 1,
+      cb?: Function): any {
     for (var i = 0; i < total; i++) {
       var j = start + i * increment;
       input.push(isFunction(cb) ? cb(j) : j);

--- a/src/collection/remove-with.pipe.ts
+++ b/src/collection/remove-with.pipe.ts
@@ -1,9 +1,8 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, objectContains, isUndefined } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'removeWith'
-})
+import {isArray, isUndefined, objectContains, toArray} from '../utils/utils';
+
+@Pipe({name: 'removeWith'})
 export class RemoveWithPipe implements PipeTransform {
   transform(collection: any, object?: any): any {
     if (!isArray(collection)) {

--- a/src/collection/remove.pipe.ts
+++ b/src/collection/remove.pipe.ts
@@ -1,9 +1,8 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, equals } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'remove'
-})
+import {equals, isArray, toArray} from '../utils/utils';
+
+@Pipe({name: 'remove'})
 export class RemovePipe implements PipeTransform {
   transform(collection: any, ...args: any[]): any {
     if (!isArray(collection)) {

--- a/src/collection/reverse.pipe.ts
+++ b/src/collection/reverse.pipe.ts
@@ -1,12 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isArray, isString } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
+import {isArray, isString} from '../utils/utils';
 
-@Pipe({
-  name: 'reverse'
-})
+@Pipe({name: 'reverse'})
 export class ReversePipe implements PipeTransform {
   transform(input: any): any {
-
     if (isString(input)) {
       return input.split('').reverse().join('');
     }

--- a/src/collection/search-field.pipe.ts
+++ b/src/collection/search-field.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isArray } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'searchField'
-})
+import {Parse} from '../utils/parse';
+import {isArray} from '../utils/utils';
+
+@Pipe({name: 'searchField'})
 export class SearchFieldPipe implements PipeTransform {
   private $parse: Function;
 
@@ -13,7 +12,6 @@ export class SearchFieldPipe implements PipeTransform {
   }
 
   transform(collection: any, ...args: any[]): any {
-
     if (!isArray(collection) || !args.length) {
       return collection;
     }

--- a/src/collection/to-array.pipe.ts
+++ b/src/collection/to-array.pipe.ts
@@ -1,23 +1,20 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isObject } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'toArray'
-})
+import {isObject, toArray} from '../utils/utils';
+
+@Pipe({name: 'toArray'})
 export class ToArrayPipe implements PipeTransform {
   transform(collection: any, addKey: boolean = false): any {
-
     if (!isObject(collection)) {
       return collection;
     }
 
-    return addKey
-      ? Object.keys(collection).map((key: string) => {
-        // TODO: object.assign polyfill
-        let o = collection[key];
-        o.$key = key;
-        return o;
-      })
-      : toArray(collection);
+    return addKey ? Object.keys(collection).map((key: string) => {
+      // TODO: object.assign polyfill
+      let o = collection[key];
+      o.$key = key;
+      return o;
+    }) :
+                    toArray(collection);
   }
 }

--- a/src/collection/uniq.pipe.ts
+++ b/src/collection/uniq.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isArray, toArray, isUndefined } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'uniq'
-})
+import {Parse} from '../utils/parse';
+import {isArray, isUndefined, toArray} from '../utils/utils';
+
+@Pipe({name: 'uniq'})
 export class UniqPipe implements PipeTransform {
   private $parse: Function;
 
@@ -13,7 +12,6 @@ export class UniqPipe implements PipeTransform {
   }
 
   transform(collection: any, predicate?: any): any {
-
     if (!isArray(collection)) {
       collection = toArray(collection);
     }
@@ -22,9 +20,7 @@ export class UniqPipe implements PipeTransform {
       return collection.filter((e: any, i: number, self: Array<any>) => self.indexOf(e) == i);
     }
 
-    let getter = this.$parse(predicate)
-      , uniqueItems: Array<any> = []
-      ;
+    let getter = this.$parse(predicate), uniqueItems: Array<any> = [];
     return collection.filter((e: any) => {
       let v = getter(e);
       if (!isUndefined(v) && uniqueItems.some((ue: any) => ue === v)) {

--- a/src/collection/where.pipe.ts
+++ b/src/collection/where.pipe.ts
@@ -1,9 +1,8 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { toArray, isArray, objectContains, isUndefined } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'where'
-})
+import {isArray, isUndefined, objectContains, toArray} from '../utils/utils';
+
+@Pipe({name: 'where'})
 export class WherePipe implements PipeTransform {
   transform(collection: any, object?: any): any {
     if (!isArray(collection)) {

--- a/src/collection/xor.pipe.ts
+++ b/src/collection/xor.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isArray, toArray, isUndefined } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'xor'
-})
+import {Parse} from '../utils/parse';
+import {isArray, isUndefined, toArray} from '../utils/utils';
+
+@Pipe({name: 'xor'})
 export class XORPipe implements PipeTransform {
   private $parse: Function;
 
@@ -13,7 +12,6 @@ export class XORPipe implements PipeTransform {
   }
 
   transform(col1: any, col2: any, predicate?: any): any {
-
     col1 = !isArray(col1) ? toArray(col1) : col1;
     col2 = !isArray(col2) ? toArray(col2) : col2;
 
@@ -21,10 +19,9 @@ export class XORPipe implements PipeTransform {
       return col1;
     }
 
-    return col1.concat(col2)
-      .filter((elm: any) => {
-        return !(this.some(elm, col1, predicate) && this.some(elm, col2, predicate));
-      });
+    return col1.concat(col2).filter((elm: any) => {
+      return !(this.some(elm, col1, predicate) && this.some(elm, col2, predicate));
+    });
   }
 
   // TODO: add equlity check using "equals()" instead of ===

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,9 @@
-import { NgModule } from '@angular/core';
+import {NgModule} from '@angular/core';
 
-import { MathPipesModule } from './math';
-import { StringPipesModule } from './string';
-import { BooleanPipesModule } from './boolean';
-import { CollectionPipesModule } from './collection';
+import {BooleanPipesModule} from './boolean';
+import {CollectionPipesModule} from './collection';
+import {MathPipesModule} from './math';
+import {StringPipesModule} from './string';
 
 export * from './math';
 export * from './string';
@@ -18,4 +18,5 @@ export * from './collection';
     CollectionPipesModule,
   ]
 })
-export class NgPipesModule { }
+export class NgPipesModule {
+}

--- a/src/math/abs.pipe.ts
+++ b/src/math/abs.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'abs'
-})
+@Pipe({name: 'abs'})
 export class AbsPipe implements PipeTransform {
   transform(input: any): number {
     return Math.abs(Number(input));

--- a/src/math/byte-fmt.pipe.ts
+++ b/src/math/byte-fmt.pipe.ts
@@ -1,21 +1,20 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isNumber, convertToDecimal } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'byteFmt'
-})
+import {convertToDecimal, isNumber} from '../utils/utils';
+
+@Pipe({name: 'byteFmt'})
 export class ByteFmtPipe implements PipeTransform {
   private compared: any;
 
   constructor() {
-    this.compared = [{ str: 'B', val: 1024 }];
+    this.compared = [{str: 'B', val: 1024}];
     ['KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'].forEach((el, i) => {
-      this.compared.push({ str: el, val: this.compared[i].val * 1024 });
+      this.compared.push({str: el, val: this.compared[i].val * 1024});
     });
   }
   transform(bytes: number, decimal: any): string {
     if (isNumber(decimal) && isFinite(decimal) && decimal % 1 === 0 && decimal >= 0 &&
-      isNumber(bytes) && isFinite(bytes)) {
+        isNumber(bytes) && isFinite(bytes)) {
       var i = 0;
       while (i < this.compared.length - 1 && bytes >= this.compared[i].val) i++;
       bytes /= i > 0 ? this.compared[i - 1].val : 1;

--- a/src/math/degrees.pipe.ts
+++ b/src/math/degrees.pipe.ts
@@ -1,15 +1,14 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isNumber } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
+import {isNumber} from '../utils/utils';
 
-@Pipe({
-  name: 'degrees'
-})
+@Pipe({name: 'degrees'})
 export class DegreesPipe implements PipeTransform {
   transform(radians: number, decimal: number): number {
-    // if decimal is not an integer greater than -1, we cannot do. quit with error "NaN"
+    // if decimal is not an integer greater than -1, we cannot do. quit with
+    // error "NaN"
     // if degrees is not a real number, we cannot do also. quit with error "NaN"
     if (isNumber(decimal) && isFinite(decimal) && decimal % 1 === 0 && decimal >= 0 &&
-      isNumber(radians) && isFinite(radians)) {
+        isNumber(radians) && isFinite(radians)) {
       var degrees = (radians * 180) / Math.PI;
       return Math.round(degrees * Math.pow(10, decimal)) / (Math.pow(10, decimal));
     } else {

--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -1,16 +1,16 @@
-import { NgModule } from '@angular/core';
+import {NgModule} from '@angular/core';
 
-import { AbsPipe } from './abs.pipe';
-import { ByteFmtPipe } from './byte-fmt.pipe';
-import { KBFmtPipe } from './kb-fmt.pipe';
-import { DegreesPipe } from './degrees.pipe';
-import { MaxPipe } from './max.pipe';
-import { MinPipe } from './min.pipe';
-import { PercentPipe } from './percent.pipe';
-import { RadiansPipe } from './radians.pipe';
-import { RadixPipe } from './radix.pipe';
-import { ShortFmtPipe } from './short-fmt.pipe';
-import { SumPipe } from './sum.pipe';
+import {AbsPipe} from './abs.pipe';
+import {ByteFmtPipe} from './byte-fmt.pipe';
+import {DegreesPipe} from './degrees.pipe';
+import {KBFmtPipe} from './kb-fmt.pipe';
+import {MaxPipe} from './max.pipe';
+import {MinPipe} from './min.pipe';
+import {PercentPipe} from './percent.pipe';
+import {RadiansPipe} from './radians.pipe';
+import {RadixPipe} from './radix.pipe';
+import {ShortFmtPipe} from './short-fmt.pipe';
+import {SumPipe} from './sum.pipe';
 
 export * from './abs.pipe';
 export * from './byte-fmt.pipe';
@@ -52,4 +52,5 @@ export * from './sum.pipe';
     SumPipe,
   ]
 })
-export class MathPipesModule { }
+export class MathPipesModule {
+}

--- a/src/math/kb-fmt.pipe.ts
+++ b/src/math/kb-fmt.pipe.ts
@@ -1,21 +1,20 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isNumber, convertToDecimal } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'kbFmt'
-})
+import {convertToDecimal, isNumber} from '../utils/utils';
+
+@Pipe({name: 'kbFmt'})
 export class KBFmtPipe implements PipeTransform {
   private compared: any;
 
   constructor() {
-    this.compared = [{ str: 'KB', val: 1024 }];
+    this.compared = [{str: 'KB', val: 1024}];
     ['MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'].forEach((el, i) => {
-      this.compared.push({ str: el, val: this.compared[i].val * 1024 });
+      this.compared.push({str: el, val: this.compared[i].val * 1024});
     });
   }
   transform(bytes: number, decimal: any): string {
     if (isNumber(decimal) && isFinite(decimal) && decimal % 1 === 0 && decimal >= 0 &&
-      isNumber(bytes) && isFinite(bytes)) {
+        isNumber(bytes) && isFinite(bytes)) {
       var i = 0;
       while (i < this.compared.length - 1 && bytes >= this.compared[i].val) i++;
       bytes /= i > 0 ? this.compared[i - 1].val : 1;

--- a/src/math/max.pipe.ts
+++ b/src/math/max.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isUndefined } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'max'
-})
+import {Parse} from '../utils/parse';
+import {isUndefined} from '../utils/utils';
+
+@Pipe({name: 'max'})
 export class MaxPipe implements PipeTransform {
   private $parse: Function;
 
@@ -12,9 +11,8 @@ export class MaxPipe implements PipeTransform {
     this.$parse = Parse();
   }
   transform(input: Array<any>, predicate?: any): any {
-    return isUndefined(predicate)
-      ? Math.max.apply(Math, input)
-      : input[this.index(input, this.$parse(predicate))];
+    return isUndefined(predicate) ? Math.max.apply(Math, input) :
+                                    input[this.index(input, this.$parse(predicate))];
   }
 
   private index(input: Array<any>, fn: Function): number {

--- a/src/math/min.pipe.ts
+++ b/src/math/min.pipe.ts
@@ -1,10 +1,9 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isUndefined } from '../utils/utils';
-import { Parse } from '../utils/parse';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'min'
-})
+import {Parse} from '../utils/parse';
+import {isUndefined} from '../utils/utils';
+
+@Pipe({name: 'min'})
 export class MinPipe implements PipeTransform {
   private $parse: Function;
 
@@ -12,9 +11,8 @@ export class MinPipe implements PipeTransform {
     this.$parse = Parse();
   }
   transform(input: Array<any>, predicate?: any): any {
-    return isUndefined(predicate)
-      ? Math.min.apply(Math, input)
-      : input[this.index(input, this.$parse(predicate))];
+    return isUndefined(predicate) ? Math.min.apply(Math, input) :
+                                    input[this.index(input, this.$parse(predicate))];
   }
 
   private index(input: Array<any>, fn: Function): number {

--- a/src/math/percent.pipe.ts
+++ b/src/math/percent.pipe.ts
@@ -1,9 +1,7 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isNumber, isString } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
+import {isNumber, isString} from '../utils/utils';
 
-@Pipe({
-  name: 'percent'
-})
+@Pipe({name: 'percent'})
 export class PercentPipe implements PipeTransform {
   transform(input: any, divided: number = 100, round: boolean = false): any {
     let divider: any = input;
@@ -13,8 +11,6 @@ export class PercentPipe implements PipeTransform {
     if (!isNumber(divider) || isNaN(divider)) {
       return input;
     }
-    return round
-      ? Math.round((divider / divided) * 100)
-      : (divider / divided) * 100;
+    return round ? Math.round((divider / divided) * 100) : (divider / divided) * 100;
   }
 }

--- a/src/math/radians.pipe.ts
+++ b/src/math/radians.pipe.ts
@@ -1,15 +1,14 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isNumber } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
+import {isNumber} from '../utils/utils';
 
-@Pipe({
-  name: 'radians'
-})
+@Pipe({name: 'radians'})
 export class RadiansPipe implements PipeTransform {
   transform(degrees: number, decimal: number): number {
-    // if decimal is not an integer greater than -1, we cannot do. quit with error "NaN"
+    // if decimal is not an integer greater than -1, we cannot do. quit with
+    // error "NaN"
     // if degrees is not a real number, we cannot do also. quit with error "NaN"
     if (isNumber(decimal) && isFinite(decimal) && decimal % 1 === 0 && decimal >= 0 &&
-      isNumber(degrees) && isFinite(degrees)) {
+        isNumber(degrees) && isFinite(degrees)) {
       var radians = (degrees * 3.14159265359) / 180;
       return Math.round(radians * Math.pow(10, decimal)) / (Math.pow(10, decimal));
     }

--- a/src/math/radix.pipe.ts
+++ b/src/math/radix.pipe.ts
@@ -1,9 +1,7 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isNumber } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
+import {isNumber} from '../utils/utils';
 
-@Pipe({
-  name: 'radix'
-})
+@Pipe({name: 'radix'})
 export class RadixPipe implements PipeTransform {
   transform(input: any, radix: number): string {
     let RANGE = /^[2-9]$|^[1-2]\d$|^3[0-6]$/;

--- a/src/math/short-fmt.pipe.ts
+++ b/src/math/short-fmt.pipe.ts
@@ -1,13 +1,12 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isNumber, convertToDecimal } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'shortFmt'
-})
+import {convertToDecimal, isNumber} from '../utils/utils';
+
+@Pipe({name: 'shortFmt'})
 export class ShortFmtPipe implements PipeTransform {
   transform(number: any, decimal: any): string {
     if (isNumber(decimal) && isFinite(decimal) && decimal % 1 === 0 && decimal >= 0 &&
-      isNumber(number) && isFinite(number)) {
+        isNumber(number) && isFinite(number)) {
       if (number < 1e3) {
         return '' + number;  // Coerce to string
       } else if (number < 1e6) {
@@ -17,7 +16,6 @@ export class ShortFmtPipe implements PipeTransform {
       } else {
         return convertToDecimal((number / 1e9), decimal) + ' B';
       }
-
     }
     return 'NaN';
   }

--- a/src/math/sum.pipe.ts
+++ b/src/math/sum.pipe.ts
@@ -1,9 +1,7 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isArray } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
+import {isArray} from '../utils/utils';
 
-@Pipe({
-  name: 'sum'
-})
+@Pipe({name: 'sum'})
 export class SumPipe implements PipeTransform {
   transform(array: any, initial: number = 0): any {
     if (!isArray(array)) {

--- a/src/string/ends-with.pipe.ts
+++ b/src/string/ends-with.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'endsWith'
-})
+@Pipe({name: 'endsWith'})
 export class EndsWithPipe implements PipeTransform {
   transform(input: string, ends?: string, csensitive: boolean = false): boolean {
     if (ends == '') {

--- a/src/string/index.ts
+++ b/src/string/index.ts
@@ -1,23 +1,23 @@
-import { NgModule } from '@angular/core';
+import {NgModule} from '@angular/core';
 
-import { EndsWithPipe } from './ends-with.pipe';
-import { StartsWithPipe } from './starts-with.pipe';
-import { LatinizePipe } from './latinize.pipe';
-import { LeftTrimPipe } from './ltrim.pipe';
-import { RightTrimPipe } from './rtrim.pipe';
-import { TrimPipe } from './trim.pipe';
-import { MatchPipe } from './match.pipe';
-import { RepeatPipe } from './repeat.pipe';
-import { SlugifyPipe } from './slugify.pipe';
-import { StringularPipe } from './stringular.pipe';
-import { StripTagsPipe } from './strip-tags.pipe';
-import { TestPipe } from './test.pipe';
-import { TruncatePipe } from './truncate.pipe';
-import { UcfirstPipe } from './ucfirst.pipe';
-import { TitleizePipe } from './titleize.pipe';
-import { UriComponentEncodePipe } from './uri-component-encode.pipe';
-import { UriEncodePipe } from './uri-encode.pipe';
-import { WrapPipe } from './wrap.pipe';
+import {EndsWithPipe} from './ends-with.pipe';
+import {LatinizePipe} from './latinize.pipe';
+import {LeftTrimPipe} from './ltrim.pipe';
+import {MatchPipe} from './match.pipe';
+import {RepeatPipe} from './repeat.pipe';
+import {RightTrimPipe} from './rtrim.pipe';
+import {SlugifyPipe} from './slugify.pipe';
+import {StartsWithPipe} from './starts-with.pipe';
+import {StringularPipe} from './stringular.pipe';
+import {StripTagsPipe} from './strip-tags.pipe';
+import {TestPipe} from './test.pipe';
+import {TitleizePipe} from './titleize.pipe';
+import {TrimPipe} from './trim.pipe';
+import {TruncatePipe} from './truncate.pipe';
+import {UcfirstPipe} from './ucfirst.pipe';
+import {UriComponentEncodePipe} from './uri-component-encode.pipe';
+import {UriEncodePipe} from './uri-encode.pipe';
+import {WrapPipe} from './wrap.pipe';
 
 export * from './ends-with.pipe';
 export * from './starts-with.pipe';
@@ -80,4 +80,5 @@ export * from './wrap.pipe';
     WrapPipe,
   ]
 })
-export class StringPipesModule { }
+export class StringPipesModule {
+}

--- a/src/string/latinize.pipe.ts
+++ b/src/string/latinize.pipe.ts
@@ -1,98 +1,233 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'latinize'
-})
+@Pipe({name: 'latinize'})
 export class LatinizePipe implements PipeTransform {
   private diacriticsMap: any;
   constructor() {
     let defaultDiacriticsRemovalap = [
-      { 'base': 'A', 'letters': '\u0041\u24B6\uFF21\u00C0\u00C1\u00C2\u1EA6\u1EA4\u1EAA\u1EA8\u00C3\u0100\u0102\u1EB0\u1EAE\u1EB4\u1EB2\u0226\u01E0\u00C4\u01DE\u1EA2\u00C5\u01FA\u01CD\u0200\u0202\u1EA0\u1EAC\u1EB6\u1E00\u0104\u023A\u2C6F' },
-      { 'base': 'AA', 'letters': '\uA732' },
-      { 'base': 'AE', 'letters': '\u00C6\u01FC\u01E2' },
-      { 'base': 'AO', 'letters': '\uA734' },
-      { 'base': 'AU', 'letters': '\uA736' },
-      { 'base': 'AV', 'letters': '\uA738\uA73A' },
-      { 'base': 'AY', 'letters': '\uA73C' },
-      { 'base': 'B', 'letters': '\u0042\u24B7\uFF22\u1E02\u1E04\u1E06\u0243\u0182\u0181' },
-      { 'base': 'C', 'letters': '\u0043\u24B8\uFF23\u0106\u0108\u010A\u010C\u00C7\u1E08\u0187\u023B\uA73E' },
-      { 'base': 'D', 'letters': '\u0044\u24B9\uFF24\u1E0A\u010E\u1E0C\u1E10\u1E12\u1E0E\u0110\u018B\u018A\u0189\uA779' },
-      { 'base': 'DZ', 'letters': '\u01F1\u01C4' },
-      { 'base': 'Dz', 'letters': '\u01F2\u01C5' },
-      { 'base': 'E', 'letters': '\u0045\u24BA\uFF25\u00C8\u00C9\u00CA\u1EC0\u1EBE\u1EC4\u1EC2\u1EBC\u0112\u1E14\u1E16\u0114\u0116\u00CB\u1EBA\u011A\u0204\u0206\u1EB8\u1EC6\u0228\u1E1C\u0118\u1E18\u1E1A\u0190\u018E' },
-      { 'base': 'F', 'letters': '\u0046\u24BB\uFF26\u1E1E\u0191\uA77B' },
-      { 'base': 'G', 'letters': '\u0047\u24BC\uFF27\u01F4\u011C\u1E20\u011E\u0120\u01E6\u0122\u01E4\u0193\uA7A0\uA77D\uA77E' },
-      { 'base': 'H', 'letters': '\u0048\u24BD\uFF28\u0124\u1E22\u1E26\u021E\u1E24\u1E28\u1E2A\u0126\u2C67\u2C75\uA78D' },
-      { 'base': 'I', 'letters': '\u0049\u24BE\uFF29\u00CC\u00CD\u00CE\u0128\u012A\u012C\u0130\u00CF\u1E2E\u1EC8\u01CF\u0208\u020A\u1ECA\u012E\u1E2C\u0197' },
-      { 'base': 'J', 'letters': '\u004A\u24BF\uFF2A\u0134\u0248' },
-      { 'base': 'K', 'letters': '\u004B\u24C0\uFF2B\u1E30\u01E8\u1E32\u0136\u1E34\u0198\u2C69\uA740\uA742\uA744\uA7A2' },
-      { 'base': 'L', 'letters': '\u004C\u24C1\uFF2C\u013F\u0139\u013D\u1E36\u1E38\u013B\u1E3C\u1E3A\u0141\u023D\u2C62\u2C60\uA748\uA746\uA780' },
-      { 'base': 'LJ', 'letters': '\u01C7' },
-      { 'base': 'Lj', 'letters': '\u01C8' },
-      { 'base': 'M', 'letters': '\u004D\u24C2\uFF2D\u1E3E\u1E40\u1E42\u2C6E\u019C' },
-      { 'base': 'N', 'letters': '\u004E\u24C3\uFF2E\u01F8\u0143\u00D1\u1E44\u0147\u1E46\u0145\u1E4A\u1E48\u0220\u019D\uA790\uA7A4' },
-      { 'base': 'NJ', 'letters': '\u01CA' },
-      { 'base': 'Nj', 'letters': '\u01CB' },
-      { 'base': 'O', 'letters': '\u004F\u24C4\uFF2F\u00D2\u00D3\u00D4\u1ED2\u1ED0\u1ED6\u1ED4\u00D5\u1E4C\u022C\u1E4E\u014C\u1E50\u1E52\u014E\u022E\u0230\u00D6\u022A\u1ECE\u0150\u01D1\u020C\u020E\u01A0\u1EDC\u1EDA\u1EE0\u1EDE\u1EE2\u1ECC\u1ED8\u01EA\u01EC\u00D8\u01FE\u0186\u019F\uA74A\uA74C' },
-      { 'base': 'OI', 'letters': '\u01A2' },
-      { 'base': 'OO', 'letters': '\uA74E' },
-      { 'base': 'OU', 'letters': '\u0222' },
-      { 'base': 'OE', 'letters': '\u008C\u0152' },
-      { 'base': 'oe', 'letters': '\u009C\u0153' },
-      { 'base': 'P', 'letters': '\u0050\u24C5\uFF30\u1E54\u1E56\u01A4\u2C63\uA750\uA752\uA754' },
-      { 'base': 'Q', 'letters': '\u0051\u24C6\uFF31\uA756\uA758\u024A' },
-      { 'base': 'R', 'letters': '\u0052\u24C7\uFF32\u0154\u1E58\u0158\u0210\u0212\u1E5A\u1E5C\u0156\u1E5E\u024C\u2C64\uA75A\uA7A6\uA782' },
-      { 'base': 'S', 'letters': '\u0053\u24C8\uFF33\u1E9E\u015A\u1E64\u015C\u1E60\u0160\u1E66\u1E62\u1E68\u0218\u015E\u2C7E\uA7A8\uA784' },
-      { 'base': 'T', 'letters': '\u0054\u24C9\uFF34\u1E6A\u0164\u1E6C\u021A\u0162\u1E70\u1E6E\u0166\u01AC\u01AE\u023E\uA786' },
-      { 'base': 'TZ', 'letters': '\uA728' },
-      { 'base': 'U', 'letters': '\u0055\u24CA\uFF35\u00D9\u00DA\u00DB\u0168\u1E78\u016A\u1E7A\u016C\u00DC\u01DB\u01D7\u01D5\u01D9\u1EE6\u016E\u0170\u01D3\u0214\u0216\u01AF\u1EEA\u1EE8\u1EEE\u1EEC\u1EF0\u1EE4\u1E72\u0172\u1E76\u1E74\u0244' },
-      { 'base': 'V', 'letters': '\u0056\u24CB\uFF36\u1E7C\u1E7E\u01B2\uA75E\u0245' },
-      { 'base': 'VY', 'letters': '\uA760' },
-      { 'base': 'W', 'letters': '\u0057\u24CC\uFF37\u1E80\u1E82\u0174\u1E86\u1E84\u1E88\u2C72' },
-      { 'base': 'X', 'letters': '\u0058\u24CD\uFF38\u1E8A\u1E8C' },
-      { 'base': 'Y', 'letters': '\u0059\u24CE\uFF39\u1EF2\u00DD\u0176\u1EF8\u0232\u1E8E\u0178\u1EF6\u1EF4\u01B3\u024E\u1EFE' },
-      { 'base': 'Z', 'letters': '\u005A\u24CF\uFF3A\u0179\u1E90\u017B\u017D\u1E92\u1E94\u01B5\u0224\u2C7F\u2C6B\uA762' },
-      { 'base': 'a', 'letters': '\u0061\u24D0\uFF41\u1E9A\u00E0\u00E1\u00E2\u1EA7\u1EA5\u1EAB\u1EA9\u00E3\u0101\u0103\u1EB1\u1EAF\u1EB5\u1EB3\u0227\u01E1\u00E4\u01DF\u1EA3\u00E5\u01FB\u01CE\u0201\u0203\u1EA1\u1EAD\u1EB7\u1E01\u0105\u2C65\u0250' },
-      { 'base': 'aa', 'letters': '\uA733' },
-      { 'base': 'ae', 'letters': '\u00E6\u01FD\u01E3' },
-      { 'base': 'ao', 'letters': '\uA735' },
-      { 'base': 'au', 'letters': '\uA737' },
-      { 'base': 'av', 'letters': '\uA739\uA73B' },
-      { 'base': 'ay', 'letters': '\uA73D' },
-      { 'base': 'b', 'letters': '\u0062\u24D1\uFF42\u1E03\u1E05\u1E07\u0180\u0183\u0253' },
-      { 'base': 'c', 'letters': '\u0063\u24D2\uFF43\u0107\u0109\u010B\u010D\u00E7\u1E09\u0188\u023C\uA73F\u2184' },
-      { 'base': 'd', 'letters': '\u0064\u24D3\uFF44\u1E0B\u010F\u1E0D\u1E11\u1E13\u1E0F\u0111\u018C\u0256\u0257\uA77A' },
-      { 'base': 'dz', 'letters': '\u01F3\u01C6' },
-      { 'base': 'e', 'letters': '\u0065\u24D4\uFF45\u00E8\u00E9\u00EA\u1EC1\u1EBF\u1EC5\u1EC3\u1EBD\u0113\u1E15\u1E17\u0115\u0117\u00EB\u1EBB\u011B\u0205\u0207\u1EB9\u1EC7\u0229\u1E1D\u0119\u1E19\u1E1B\u0247\u025B\u01DD' },
-      { 'base': 'f', 'letters': '\u0066\u24D5\uFF46\u1E1F\u0192\uA77C' },
-      { 'base': 'g', 'letters': '\u0067\u24D6\uFF47\u01F5\u011D\u1E21\u011F\u0121\u01E7\u0123\u01E5\u0260\uA7A1\u1D79\uA77F' },
-      { 'base': 'h', 'letters': '\u0068\u24D7\uFF48\u0125\u1E23\u1E27\u021F\u1E25\u1E29\u1E2B\u1E96\u0127\u2C68\u2C76\u0265' },
-      { 'base': 'hv', 'letters': '\u0195' },
-      { 'base': 'i', 'letters': '\u0069\u24D8\uFF49\u00EC\u00ED\u00EE\u0129\u012B\u012D\u00EF\u1E2F\u1EC9\u01D0\u0209\u020B\u1ECB\u012F\u1E2D\u0268\u0131' },
-      { 'base': 'j', 'letters': '\u006A\u24D9\uFF4A\u0135\u01F0\u0249' },
-      { 'base': 'k', 'letters': '\u006B\u24DA\uFF4B\u1E31\u01E9\u1E33\u0137\u1E35\u0199\u2C6A\uA741\uA743\uA745\uA7A3' },
-      { 'base': 'l', 'letters': '\u006C\u24DB\uFF4C\u0140\u013A\u013E\u1E37\u1E39\u013C\u1E3D\u1E3B\u017F\u0142\u019A\u026B\u2C61\uA749\uA781\uA747' },
-      { 'base': 'lj', 'letters': '\u01C9' },
-      { 'base': 'm', 'letters': '\u006D\u24DC\uFF4D\u1E3F\u1E41\u1E43\u0271\u026F' },
-      { 'base': 'n', 'letters': '\u006E\u24DD\uFF4E\u01F9\u0144\u00F1\u1E45\u0148\u1E47\u0146\u1E4B\u1E49\u019E\u0272\u0149\uA791\uA7A5' },
-      { 'base': 'nj', 'letters': '\u01CC' },
-      { 'base': 'o', 'letters': '\u006F\u24DE\uFF4F\u00F2\u00F3\u00F4\u1ED3\u1ED1\u1ED7\u1ED5\u00F5\u1E4D\u022D\u1E4F\u014D\u1E51\u1E53\u014F\u022F\u0231\u00F6\u022B\u1ECF\u0151\u01D2\u020D\u020F\u01A1\u1EDD\u1EDB\u1EE1\u1EDF\u1EE3\u1ECD\u1ED9\u01EB\u01ED\u00F8\u01FF\u0254\uA74B\uA74D\u0275' },
-      { 'base': 'oi', 'letters': '\u01A3' },
-      { 'base': 'ou', 'letters': '\u0223' },
-      { 'base': 'oo', 'letters': '\uA74F' },
-      { 'base': 'p', 'letters': '\u0070\u24DF\uFF50\u1E55\u1E57\u01A5\u1D7D\uA751\uA753\uA755' },
-      { 'base': 'q', 'letters': '\u0071\u24E0\uFF51\u024B\uA757\uA759' },
-      { 'base': 'r', 'letters': '\u0072\u24E1\uFF52\u0155\u1E59\u0159\u0211\u0213\u1E5B\u1E5D\u0157\u1E5F\u024D\u027D\uA75B\uA7A7\uA783' },
-      { 'base': 's', 'letters': '\u0073\u24E2\uFF53\u00DF\u015B\u1E65\u015D\u1E61\u0161\u1E67\u1E63\u1E69\u0219\u015F\u023F\uA7A9\uA785\u1E9B' },
-      { 'base': 't', 'letters': '\u0074\u24E3\uFF54\u1E6B\u1E97\u0165\u1E6D\u021B\u0163\u1E71\u1E6F\u0167\u01AD\u0288\u2C66\uA787' },
-      { 'base': 'tz', 'letters': '\uA729' },
-      { 'base': 'u', 'letters': '\u0075\u24E4\uFF55\u00F9\u00FA\u00FB\u0169\u1E79\u016B\u1E7B\u016D\u00FC\u01DC\u01D8\u01D6\u01DA\u1EE7\u016F\u0171\u01D4\u0215\u0217\u01B0\u1EEB\u1EE9\u1EEF\u1EED\u1EF1\u1EE5\u1E73\u0173\u1E77\u1E75\u0289' },
-      { 'base': 'v', 'letters': '\u0076\u24E5\uFF56\u1E7D\u1E7F\u028B\uA75F\u028C' },
-      { 'base': 'vy', 'letters': '\uA761' },
-      { 'base': 'w', 'letters': '\u0077\u24E6\uFF57\u1E81\u1E83\u0175\u1E87\u1E85\u1E98\u1E89\u2C73' },
-      { 'base': 'x', 'letters': '\u0078\u24E7\uFF58\u1E8B\u1E8D' },
-      { 'base': 'y', 'letters': '\u0079\u24E8\uFF59\u1EF3\u00FD\u0177\u1EF9\u0233\u1E8F\u00FF\u1EF7\u1E99\u1EF5\u01B4\u024F\u1EFF' },
-      { 'base': 'z', 'letters': '\u007A\u24E9\uFF5A\u017A\u1E91\u017C\u017E\u1E93\u1E95\u01B6\u0225\u0240\u2C6C\uA763' }
+      {
+        'base': 'A',
+        'letters':
+            '\u0041\u24B6\uFF21\u00C0\u00C1\u00C2\u1EA6\u1EA4\u1EAA\u1EA8\u00C3\u0100\u0102\u1EB0\u1EAE\u1EB4\u1EB2\u0226\u01E0\u00C4\u01DE\u1EA2\u00C5\u01FA\u01CD\u0200\u0202\u1EA0\u1EAC\u1EB6\u1E00\u0104\u023A\u2C6F'
+      },
+      {'base': 'AA', 'letters': '\uA732'},
+      {'base': 'AE', 'letters': '\u00C6\u01FC\u01E2'},
+      {'base': 'AO', 'letters': '\uA734'},
+      {'base': 'AU', 'letters': '\uA736'},
+      {'base': 'AV', 'letters': '\uA738\uA73A'},
+      {'base': 'AY', 'letters': '\uA73C'},
+      {'base': 'B', 'letters': '\u0042\u24B7\uFF22\u1E02\u1E04\u1E06\u0243\u0182\u0181'},
+      {
+        'base': 'C',
+        'letters': '\u0043\u24B8\uFF23\u0106\u0108\u010A\u010C\u00C7\u1E08\u0187\u023B\uA73E'
+      },
+      {
+        'base': 'D',
+        'letters':
+            '\u0044\u24B9\uFF24\u1E0A\u010E\u1E0C\u1E10\u1E12\u1E0E\u0110\u018B\u018A\u0189\uA779'
+      },
+      {'base': 'DZ', 'letters': '\u01F1\u01C4'},
+      {'base': 'Dz', 'letters': '\u01F2\u01C5'},
+      {
+        'base': 'E',
+        'letters':
+            '\u0045\u24BA\uFF25\u00C8\u00C9\u00CA\u1EC0\u1EBE\u1EC4\u1EC2\u1EBC\u0112\u1E14\u1E16\u0114\u0116\u00CB\u1EBA\u011A\u0204\u0206\u1EB8\u1EC6\u0228\u1E1C\u0118\u1E18\u1E1A\u0190\u018E'
+      },
+      {'base': 'F', 'letters': '\u0046\u24BB\uFF26\u1E1E\u0191\uA77B'},
+      {
+        'base': 'G',
+        'letters':
+            '\u0047\u24BC\uFF27\u01F4\u011C\u1E20\u011E\u0120\u01E6\u0122\u01E4\u0193\uA7A0\uA77D\uA77E'
+      },
+      {
+        'base': 'H',
+        'letters':
+            '\u0048\u24BD\uFF28\u0124\u1E22\u1E26\u021E\u1E24\u1E28\u1E2A\u0126\u2C67\u2C75\uA78D'
+      },
+      {
+        'base': 'I',
+        'letters':
+            '\u0049\u24BE\uFF29\u00CC\u00CD\u00CE\u0128\u012A\u012C\u0130\u00CF\u1E2E\u1EC8\u01CF\u0208\u020A\u1ECA\u012E\u1E2C\u0197'
+      },
+      {'base': 'J', 'letters': '\u004A\u24BF\uFF2A\u0134\u0248'},
+      {
+        'base': 'K',
+        'letters':
+            '\u004B\u24C0\uFF2B\u1E30\u01E8\u1E32\u0136\u1E34\u0198\u2C69\uA740\uA742\uA744\uA7A2'
+      },
+      {
+        'base': 'L',
+        'letters':
+            '\u004C\u24C1\uFF2C\u013F\u0139\u013D\u1E36\u1E38\u013B\u1E3C\u1E3A\u0141\u023D\u2C62\u2C60\uA748\uA746\uA780'
+      },
+      {'base': 'LJ', 'letters': '\u01C7'},
+      {'base': 'Lj', 'letters': '\u01C8'},
+      {'base': 'M', 'letters': '\u004D\u24C2\uFF2D\u1E3E\u1E40\u1E42\u2C6E\u019C'},
+      {
+        'base': 'N',
+        'letters':
+            '\u004E\u24C3\uFF2E\u01F8\u0143\u00D1\u1E44\u0147\u1E46\u0145\u1E4A\u1E48\u0220\u019D\uA790\uA7A4'
+      },
+      {'base': 'NJ', 'letters': '\u01CA'},
+      {'base': 'Nj', 'letters': '\u01CB'},
+      {
+        'base': 'O',
+        'letters':
+            '\u004F\u24C4\uFF2F\u00D2\u00D3\u00D4\u1ED2\u1ED0\u1ED6\u1ED4\u00D5\u1E4C\u022C\u1E4E\u014C\u1E50\u1E52\u014E\u022E\u0230\u00D6\u022A\u1ECE\u0150\u01D1\u020C\u020E\u01A0\u1EDC\u1EDA\u1EE0\u1EDE\u1EE2\u1ECC\u1ED8\u01EA\u01EC\u00D8\u01FE\u0186\u019F\uA74A\uA74C'
+      },
+      {'base': 'OI', 'letters': '\u01A2'},
+      {'base': 'OO', 'letters': '\uA74E'},
+      {'base': 'OU', 'letters': '\u0222'},
+      {'base': 'OE', 'letters': '\u008C\u0152'},
+      {'base': 'oe', 'letters': '\u009C\u0153'},
+      {'base': 'P', 'letters': '\u0050\u24C5\uFF30\u1E54\u1E56\u01A4\u2C63\uA750\uA752\uA754'},
+      {'base': 'Q', 'letters': '\u0051\u24C6\uFF31\uA756\uA758\u024A'},
+      {
+        'base': 'R',
+        'letters':
+            '\u0052\u24C7\uFF32\u0154\u1E58\u0158\u0210\u0212\u1E5A\u1E5C\u0156\u1E5E\u024C\u2C64\uA75A\uA7A6\uA782'
+      },
+      {
+        'base': 'S',
+        'letters':
+            '\u0053\u24C8\uFF33\u1E9E\u015A\u1E64\u015C\u1E60\u0160\u1E66\u1E62\u1E68\u0218\u015E\u2C7E\uA7A8\uA784'
+      },
+      {
+        'base': 'T',
+        'letters':
+            '\u0054\u24C9\uFF34\u1E6A\u0164\u1E6C\u021A\u0162\u1E70\u1E6E\u0166\u01AC\u01AE\u023E\uA786'
+      },
+      {'base': 'TZ', 'letters': '\uA728'},
+      {
+        'base': 'U',
+        'letters':
+            '\u0055\u24CA\uFF35\u00D9\u00DA\u00DB\u0168\u1E78\u016A\u1E7A\u016C\u00DC\u01DB\u01D7\u01D5\u01D9\u1EE6\u016E\u0170\u01D3\u0214\u0216\u01AF\u1EEA\u1EE8\u1EEE\u1EEC\u1EF0\u1EE4\u1E72\u0172\u1E76\u1E74\u0244'
+      },
+      {'base': 'V', 'letters': '\u0056\u24CB\uFF36\u1E7C\u1E7E\u01B2\uA75E\u0245'},
+      {'base': 'VY', 'letters': '\uA760'},
+      {'base': 'W', 'letters': '\u0057\u24CC\uFF37\u1E80\u1E82\u0174\u1E86\u1E84\u1E88\u2C72'},
+      {'base': 'X', 'letters': '\u0058\u24CD\uFF38\u1E8A\u1E8C'},
+      {
+        'base': 'Y',
+        'letters':
+            '\u0059\u24CE\uFF39\u1EF2\u00DD\u0176\u1EF8\u0232\u1E8E\u0178\u1EF6\u1EF4\u01B3\u024E\u1EFE'
+      },
+      {
+        'base': 'Z',
+        'letters':
+            '\u005A\u24CF\uFF3A\u0179\u1E90\u017B\u017D\u1E92\u1E94\u01B5\u0224\u2C7F\u2C6B\uA762'
+      },
+      {
+        'base': 'a',
+        'letters':
+            '\u0061\u24D0\uFF41\u1E9A\u00E0\u00E1\u00E2\u1EA7\u1EA5\u1EAB\u1EA9\u00E3\u0101\u0103\u1EB1\u1EAF\u1EB5\u1EB3\u0227\u01E1\u00E4\u01DF\u1EA3\u00E5\u01FB\u01CE\u0201\u0203\u1EA1\u1EAD\u1EB7\u1E01\u0105\u2C65\u0250'
+      },
+      {'base': 'aa', 'letters': '\uA733'},
+      {'base': 'ae', 'letters': '\u00E6\u01FD\u01E3'},
+      {'base': 'ao', 'letters': '\uA735'},
+      {'base': 'au', 'letters': '\uA737'},
+      {'base': 'av', 'letters': '\uA739\uA73B'},
+      {'base': 'ay', 'letters': '\uA73D'},
+      {'base': 'b', 'letters': '\u0062\u24D1\uFF42\u1E03\u1E05\u1E07\u0180\u0183\u0253'},
+      {
+        'base': 'c',
+        'letters': '\u0063\u24D2\uFF43\u0107\u0109\u010B\u010D\u00E7\u1E09\u0188\u023C\uA73F\u2184'
+      },
+      {
+        'base': 'd',
+        'letters':
+            '\u0064\u24D3\uFF44\u1E0B\u010F\u1E0D\u1E11\u1E13\u1E0F\u0111\u018C\u0256\u0257\uA77A'
+      },
+      {'base': 'dz', 'letters': '\u01F3\u01C6'},
+      {
+        'base': 'e',
+        'letters':
+            '\u0065\u24D4\uFF45\u00E8\u00E9\u00EA\u1EC1\u1EBF\u1EC5\u1EC3\u1EBD\u0113\u1E15\u1E17\u0115\u0117\u00EB\u1EBB\u011B\u0205\u0207\u1EB9\u1EC7\u0229\u1E1D\u0119\u1E19\u1E1B\u0247\u025B\u01DD'
+      },
+      {'base': 'f', 'letters': '\u0066\u24D5\uFF46\u1E1F\u0192\uA77C'},
+      {
+        'base': 'g',
+        'letters':
+            '\u0067\u24D6\uFF47\u01F5\u011D\u1E21\u011F\u0121\u01E7\u0123\u01E5\u0260\uA7A1\u1D79\uA77F'
+      },
+      {
+        'base': 'h',
+        'letters':
+            '\u0068\u24D7\uFF48\u0125\u1E23\u1E27\u021F\u1E25\u1E29\u1E2B\u1E96\u0127\u2C68\u2C76\u0265'
+      },
+      {'base': 'hv', 'letters': '\u0195'},
+      {
+        'base': 'i',
+        'letters':
+            '\u0069\u24D8\uFF49\u00EC\u00ED\u00EE\u0129\u012B\u012D\u00EF\u1E2F\u1EC9\u01D0\u0209\u020B\u1ECB\u012F\u1E2D\u0268\u0131'
+      },
+      {'base': 'j', 'letters': '\u006A\u24D9\uFF4A\u0135\u01F0\u0249'},
+      {
+        'base': 'k',
+        'letters':
+            '\u006B\u24DA\uFF4B\u1E31\u01E9\u1E33\u0137\u1E35\u0199\u2C6A\uA741\uA743\uA745\uA7A3'
+      },
+      {
+        'base': 'l',
+        'letters':
+            '\u006C\u24DB\uFF4C\u0140\u013A\u013E\u1E37\u1E39\u013C\u1E3D\u1E3B\u017F\u0142\u019A\u026B\u2C61\uA749\uA781\uA747'
+      },
+      {'base': 'lj', 'letters': '\u01C9'},
+      {'base': 'm', 'letters': '\u006D\u24DC\uFF4D\u1E3F\u1E41\u1E43\u0271\u026F'},
+      {
+        'base': 'n',
+        'letters':
+            '\u006E\u24DD\uFF4E\u01F9\u0144\u00F1\u1E45\u0148\u1E47\u0146\u1E4B\u1E49\u019E\u0272\u0149\uA791\uA7A5'
+      },
+      {'base': 'nj', 'letters': '\u01CC'},
+      {
+        'base': 'o',
+        'letters':
+            '\u006F\u24DE\uFF4F\u00F2\u00F3\u00F4\u1ED3\u1ED1\u1ED7\u1ED5\u00F5\u1E4D\u022D\u1E4F\u014D\u1E51\u1E53\u014F\u022F\u0231\u00F6\u022B\u1ECF\u0151\u01D2\u020D\u020F\u01A1\u1EDD\u1EDB\u1EE1\u1EDF\u1EE3\u1ECD\u1ED9\u01EB\u01ED\u00F8\u01FF\u0254\uA74B\uA74D\u0275'
+      },
+      {'base': 'oi', 'letters': '\u01A3'},
+      {'base': 'ou', 'letters': '\u0223'},
+      {'base': 'oo', 'letters': '\uA74F'},
+      {'base': 'p', 'letters': '\u0070\u24DF\uFF50\u1E55\u1E57\u01A5\u1D7D\uA751\uA753\uA755'},
+      {'base': 'q', 'letters': '\u0071\u24E0\uFF51\u024B\uA757\uA759'},
+      {
+        'base': 'r',
+        'letters':
+            '\u0072\u24E1\uFF52\u0155\u1E59\u0159\u0211\u0213\u1E5B\u1E5D\u0157\u1E5F\u024D\u027D\uA75B\uA7A7\uA783'
+      },
+      {
+        'base': 's',
+        'letters':
+            '\u0073\u24E2\uFF53\u00DF\u015B\u1E65\u015D\u1E61\u0161\u1E67\u1E63\u1E69\u0219\u015F\u023F\uA7A9\uA785\u1E9B'
+      },
+      {
+        'base': 't',
+        'letters':
+            '\u0074\u24E3\uFF54\u1E6B\u1E97\u0165\u1E6D\u021B\u0163\u1E71\u1E6F\u0167\u01AD\u0288\u2C66\uA787'
+      },
+      {'base': 'tz', 'letters': '\uA729'},
+      {
+        'base': 'u',
+        'letters':
+            '\u0075\u24E4\uFF55\u00F9\u00FA\u00FB\u0169\u1E79\u016B\u1E7B\u016D\u00FC\u01DC\u01D8\u01D6\u01DA\u1EE7\u016F\u0171\u01D4\u0215\u0217\u01B0\u1EEB\u1EE9\u1EEF\u1EED\u1EF1\u1EE5\u1E73\u0173\u1E77\u1E75\u0289'
+      },
+      {'base': 'v', 'letters': '\u0076\u24E5\uFF56\u1E7D\u1E7F\u028B\uA75F\u028C'},
+      {'base': 'vy', 'letters': '\uA761'},
+      {
+        'base': 'w',
+        'letters': '\u0077\u24E6\uFF57\u1E81\u1E83\u0175\u1E87\u1E85\u1E98\u1E89\u2C73'
+      },
+      {'base': 'x', 'letters': '\u0078\u24E7\uFF58\u1E8B\u1E8D'},
+      {
+        'base': 'y',
+        'letters':
+            '\u0079\u24E8\uFF59\u1EF3\u00FD\u0177\u1EF9\u0233\u1E8F\u00FF\u1EF7\u1E99\u1EF5\u01B4\u024F\u1EFF'
+      },
+      {
+        'base': 'z',
+        'letters':
+            '\u007A\u24E9\uFF5A\u017A\u1E91\u017C\u017E\u1E93\u1E95\u01B6\u0225\u0240\u2C6C\uA763'
+      }
     ];
     this.diacriticsMap = {};
     for (let i = 0; i < defaultDiacriticsRemovalap.length; i += 1) {

--- a/src/string/ltrim.pipe.ts
+++ b/src/string/ltrim.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'ltrim'
-})
+@Pipe({name: 'ltrim'})
 export class LeftTrimPipe implements PipeTransform {
   transform(input: string, chars: string = '\\s'): string {
     return input.replace(new RegExp('^' + chars + '+'), '')

--- a/src/string/match.pipe.ts
+++ b/src/string/match.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'match'
-})
+@Pipe({name: 'match'})
 export class MatchPipe implements PipeTransform {
   transform(input: string, pattern?: string, flag?: string): RegExpMatchArray {
     return input.match(new RegExp(pattern, flag));

--- a/src/string/repeat.pipe.ts
+++ b/src/string/repeat.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'repeat'
-})
+@Pipe({name: 'repeat'})
 export class RepeatPipe implements PipeTransform {
   transform(input: string, times: number = 1, separator: string = ''): string {
     let ret = input;

--- a/src/string/rtrim.pipe.ts
+++ b/src/string/rtrim.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'rtrim'
-})
+@Pipe({name: 'rtrim'})
 export class RightTrimPipe implements PipeTransform {
   transform(input: string, chars: string = '\\s'): string {
     return input.replace(new RegExp(chars + '+$'), '');

--- a/src/string/slugify.pipe.ts
+++ b/src/string/slugify.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'slugify'
-})
+@Pipe({name: 'slugify'})
 export class SlugifyPipe implements PipeTransform {
   transform(input: string, sub: any = '-'): string {
     return input.toLowerCase().replace(/\s+/g, sub);

--- a/src/string/starts-with.pipe.ts
+++ b/src/string/starts-with.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'startsWith'
-})
+@Pipe({name: 'startsWith'})
 export class StartsWithPipe implements PipeTransform {
   transform(input: string, ends?: string, csensitive: boolean = false): boolean {
     if (ends == '') {

--- a/src/string/stringular.pipe.ts
+++ b/src/string/stringular.pipe.ts
@@ -1,9 +1,7 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isUndefined } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
+import {isUndefined} from '../utils/utils';
 
-@Pipe({
-  name: 'stringular'
-})
+@Pipe({name: 'stringular'})
 export class StringularPipe implements PipeTransform {
   transform(template: string, ...args: string[]): string {
     return template.replace(/{(\d+)}/g, (match, number) => {

--- a/src/string/strip-tags.pipe.ts
+++ b/src/string/strip-tags.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'stripTags'
-})
+@Pipe({name: 'stripTags'})
 export class StripTagsPipe implements PipeTransform {
   transform(input: string): string {
     return input.replace(/<\S[^><]*>/g, '');

--- a/src/string/test.pipe.ts
+++ b/src/string/test.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'test'
-})
+@Pipe({name: 'test'})
 export class TestPipe implements PipeTransform {
   transform(input: string, pattern?: string, flag?: string): boolean {
     return new RegExp(pattern, flag).test(input);

--- a/src/string/titleize.pipe.ts
+++ b/src/string/titleize.pipe.ts
@@ -1,12 +1,10 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'titleize'
-})
+@Pipe({name: 'titleize'})
 export class TitleizePipe implements PipeTransform {
   transform(input: string): string {
     return input.split(' ')
-      .map(w => w.charAt(0).toUpperCase() + w.substring(1).toLowerCase())
-      .join(' ');
+        .map(w => w.charAt(0).toUpperCase() + w.substring(1).toLowerCase())
+        .join(' ');
   }
 }

--- a/src/string/trim.pipe.ts
+++ b/src/string/trim.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'trim'
-})
+@Pipe({name: 'trim'})
 export class TrimPipe implements PipeTransform {
   transform(input: string, chars: string = '\\s'): string {
     return input.replace(new RegExp('^' + chars + '+|' + chars + '+$', 'g'), '');

--- a/src/string/truncate.pipe.ts
+++ b/src/string/truncate.pipe.ts
@@ -1,16 +1,17 @@
-import { Pipe, PipeTransform } from '@angular/core';
-import { isUndefined } from '../utils/utils';
+import {Pipe, PipeTransform} from '@angular/core';
+import {isUndefined} from '../utils/utils';
 
-@Pipe({
-  name: 'truncate'
-})
+@Pipe({name: 'truncate'})
 export class TruncatePipe implements PipeTransform {
   transform(input: string, length?: any, suffix: string = '', preserve: boolean = false): string {
     if (isUndefined(length) || length >= input.length) {
       return input;
     }
-    return input.substring(0, preserve
-      ? (input.indexOf(' ', length) == -1 ? input.length : input.indexOf(' ', length))
-      : length) + suffix;
+    return input.substring(
+               0,
+               preserve ?
+                   (input.indexOf(' ', length) == -1 ? input.length : input.indexOf(' ', length)) :
+                   length) +
+        suffix;
   }
 }

--- a/src/string/ucfirst.pipe.ts
+++ b/src/string/ucfirst.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'ucfirst'
-})
+@Pipe({name: 'ucfirst'})
 export class UcfirstPipe implements PipeTransform {
   transform(input: string): string {
     return input.substring(0, 1).toUpperCase() + input.substring(1);

--- a/src/string/uri-component-encode.pipe.ts
+++ b/src/string/uri-component-encode.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'uriComponentEncode'
-})
+@Pipe({name: 'uriComponentEncode'})
 export class UriComponentEncodePipe implements PipeTransform {
   transform(input: string): string {
     return encodeURIComponent(input);

--- a/src/string/uri-encode.pipe.ts
+++ b/src/string/uri-encode.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'uriEncode'
-})
+@Pipe({name: 'uriEncode'})
 export class UriEncodePipe implements PipeTransform {
   transform(input: string): string {
     return encodeURI(input);

--- a/src/string/wrap.pipe.ts
+++ b/src/string/wrap.pipe.ts
@@ -1,8 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import {Pipe, PipeTransform} from '@angular/core';
 
-@Pipe({
-  name: 'wrap'
-})
+@Pipe({name: 'wrap'})
 export class WrapPipe implements PipeTransform {
   transform(input: string, wrap: any = '', ends: any = ''): string {
     return '' + wrap + input + (ends || wrap);

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -1,4 +1,4 @@
-import { isFunction, isString, isUndefined } from './utils';
+import {isFunction, isString, isUndefined} from './utils';
 
 function createGetterFn(pathKeys: string[]): Function {
   let fn: Function = null;
@@ -12,20 +12,20 @@ function createGetterFn(pathKeys: string[]): Function {
   return fn;
 
   function finalFn(key: string) {
-    return function(scope: { [key: string]: any }, local: { [key: string]: any }) {
+    return function(scope: {[key: string]: any}, local: {[key: string]: any}) {
       if (local && local.hasOwnProperty(key)) return local[key];
       if (scope) return scope[key];
     }
   }
 
   function stepFn(key: string, next: Function) {
-    return function(scope: { [key: string]: any }, local: { [key: string]: any }) {
+    return function(scope: {[key: string]: any}, local: {[key: string]: any}) {
       return next(scope && scope[key], local && local[key]);
     }
   }
 }
 
-function setterFn(scope: { [key: string]: any }, path: string[], value: any): any {
+function setterFn(scope: {[key: string]: any}, path: string[], value: any): any {
   let s = scope;
   let i = 0;
   for (; i < path.length - 1; i++) {
@@ -38,18 +38,16 @@ function setterFn(scope: { [key: string]: any }, path: string[], value: any): an
   return scope;
 }
 
-
 /**
  * @description
  * return parse function
  * @returns {Function}
  */
 export function Parse() {
-
-  var cache: { [key: string]: Function } = {};
+  var cache: {[key: string]: Function} = {};
 
   return function(exp: any): Function {
-    let fn: any = function() { };
+    let fn: any = function() {};
 
     if (isString(exp)) {
       var cacheKey = exp.trim();
@@ -58,11 +56,11 @@ export function Parse() {
       }
       var pathKeys = exp.split('.');
       fn = cache[cacheKey] = createGetterFn(pathKeys);
-      fn.assign = function(scope: { [key: string]: any }, value: any) {
+      fn.assign = function(scope: {[key: string]: any}, value: any) {
         return setterFn(scope, pathKeys, value);
       };
     } else if (isFunction(exp)) {
-      fn = function(scope: { [key: string]: any }, local: { [key: string]: any }) {
+      fn = function(scope: {[key: string]: any}, local: {[key: string]: any}) {
         return exp(scope, local);
       }
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -57,14 +57,16 @@ export function equals(a: any, b: any) {
   return true;
 }
 
-export function objectContains(partial: { [key: string]: any }, object: { [key: string]: any }): boolean {
+export function objectContains(
+    partial: {[key: string]: any}, object: {[key: string]: any}): boolean {
   return Object.keys(partial).every((key: string) => {
     return key in object && object[key] == partial[key];
   });
 }
 
-export function deepKeys(obj: { [key: string]: any },
-  stack: any[] = [], parent: any = null, intermediate: boolean = false): string[] {
+export function deepKeys(
+    obj: {[key: string]: any}, stack: any[] = [], parent: any = null,
+    intermediate: boolean = false): string[] {
   Object.keys(obj).forEach(function(el) {
     // Escape . in the element name
     var escaped = el.replace(/\./g, '\\\.');
@@ -83,7 +85,6 @@ export function deepKeys(obj: { [key: string]: any },
   });
   return stack
 }
-
 
 /**
  * @description

--- a/test/collection/after-where.spec.pipe.ts
+++ b/test/collection/after-where.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { AfterWherePipe } from '../../src/index';
+import {AfterWherePipe} from '../../src/index';
 
 describe('AfterWherePipe', () => {
   let pipe: AfterWherePipe;
@@ -7,37 +7,35 @@ describe('AfterWherePipe', () => {
   });
 
   it('should get array and properties object, and returns all the items,' +
-    'in the collection after the first that found with the given properties including it.', () => {
+         'in the collection after the first that found with the given properties including it.',
+     () => {
 
-      let array = [{ a: 1 }, { a: 2 }, { a: 3 }]
-        , orders = [
-          { id: 1, customer: { name: 'foo' }, date: 'Tue Jul 15 2014' },
-          { id: 2, customer: { name: 'foo' }, date: 'Tue Jul 16 2014' },
-          { id: 3, customer: { name: 'foo' }, date: 'Tue Jul 17 2014' },
-          { id: 4, customer: { name: 'foo' }, date: 'Tue Jul 18 2014' },
-          { id: 5, customer: { name: 'foo' }, date: 'Tue Jul 19 2014' }
-        ];
-      expect(pipe.transform(array, { a: 2 })).toEqual([{ a: 2 }, { a: 3 }]);
-      expect(pipe.transform(orders, { date: 'Tue Jul 17 2014' })).toEqual([orders[2], orders[3], orders[4]]);
-      expect(pipe.transform(orders, { date: 'Tue Jul 10 2014' })).toEqual(orders);
-    });
+       let array = [{a: 1}, {a: 2}, {a: 3}], orders = [
+         {id: 1, customer: {name: 'foo'}, date: 'Tue Jul 15 2014'},
+         {id: 2, customer: {name: 'foo'}, date: 'Tue Jul 16 2014'},
+         {id: 3, customer: {name: 'foo'}, date: 'Tue Jul 17 2014'},
+         {id: 4, customer: {name: 'foo'}, date: 'Tue Jul 18 2014'},
+         {id: 5, customer: {name: 'foo'}, date: 'Tue Jul 19 2014'}
+       ];
+       expect(pipe.transform(array, {a: 2})).toEqual([{a: 2}, {a: 3}]);
+       expect(pipe.transform(orders, {date: 'Tue Jul 17 2014'})).toEqual([
+         orders[2], orders[3], orders[4]
+       ]);
+       expect(pipe.transform(orders, {date: 'Tue Jul 10 2014'})).toEqual(orders);
+     });
 
   it('should get object and properties object, and returns all the items,' +
-    'in the collection after the first that found with the given properties including it.', () => {
+         'in the collection after the first that found with the given properties including it.',
+     () => {
 
-      let object = {
-        0: { a: 1 },
-        1: { a: 2 },
-        2: { a: 3 },
-        3: { a: 4 }
-      }, orders = {
-        0: { id: 1, customer: { name: 'foo' }, date: 'Tue Jul 15 2014' },
-        1: { id: 2, customer: { name: 'foo' }, date: 'Tue Jul 16 2014' },
-        2: { id: 3, customer: { name: 'foo' }, date: 'Tue Jul 17 2014' },
-        3: { id: 4, customer: { name: 'foo' }, date: 'Tue Jul 18 2014' },
-        4: { id: 5, customer: { name: 'foo' }, date: 'Tue Jul 19 2014' }
-      };
-      expect(pipe.transform(object, { a: 3 })).toEqual([{ a: 3 }, { a: 4 }]);
-      expect(pipe.transform(orders, { date: 'Tue Jul 18 2014' })).toEqual([orders[3], orders[4]]);
-    });
+       let object = {0: {a: 1}, 1: {a: 2}, 2: {a: 3}, 3: {a: 4}}, orders = {
+         0: {id: 1, customer: {name: 'foo'}, date: 'Tue Jul 15 2014'},
+         1: {id: 2, customer: {name: 'foo'}, date: 'Tue Jul 16 2014'},
+         2: {id: 3, customer: {name: 'foo'}, date: 'Tue Jul 17 2014'},
+         3: {id: 4, customer: {name: 'foo'}, date: 'Tue Jul 18 2014'},
+         4: {id: 5, customer: {name: 'foo'}, date: 'Tue Jul 19 2014'}
+       };
+       expect(pipe.transform(object, {a: 3})).toEqual([{a: 3}, {a: 4}]);
+       expect(pipe.transform(orders, {date: 'Tue Jul 18 2014'})).toEqual([orders[3], orders[4]]);
+     });
 });

--- a/test/collection/after.spec.pipe.ts
+++ b/test/collection/after.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { AfterPipe } from '../../src/index';
+import {AfterPipe} from '../../src/index';
 
 describe('AfterPipe', () => {
   let pipe: AfterPipe;
@@ -7,23 +7,20 @@ describe('AfterPipe', () => {
   });
 
   it('should get array as a collection and specified count, and return all the items' +
-    'in the collection after the specified count.', () => {
-      let array = [{ a: 1 }, { a: 2 }];
-      expect(pipe.transform(array, 1)).toEqual([{ a: 2 }]);
-      expect(pipe.transform([1, 2, 3, 4], 1)).toEqual([2, 3, 4]);
-      expect(pipe.transform([1, 2, 3, 4], 5)).toEqual([]);
-    });
+         'in the collection after the specified count.',
+     () => {
+       let array = [{a: 1}, {a: 2}];
+       expect(pipe.transform(array, 1)).toEqual([{a: 2}]);
+       expect(pipe.transform([1, 2, 3, 4], 1)).toEqual([2, 3, 4]);
+       expect(pipe.transform([1, 2, 3, 4], 5)).toEqual([]);
+     });
 
   it('should get object as a collection and specified count, and return all the items' +
-    'in the collection after the specified count.', () => {
-      let object = {
-        0: { a: 1 },
-        1: { a: 2 },
-        2: { a: 3 },
-        3: { a: 4 }
-      };
-      expect(pipe.transform(object, 3)).toEqual([{ a: 4 }]);
-      expect(pipe.transform(object, 2)).toEqual([{ a: 3 }, { a: 4 }]);
-      expect(pipe.transform(object, 10)).toEqual([]);
-    });
+         'in the collection after the specified count.',
+     () => {
+       let object = {0: {a: 1}, 1: {a: 2}, 2: {a: 3}, 3: {a: 4}};
+       expect(pipe.transform(object, 3)).toEqual([{a: 4}]);
+       expect(pipe.transform(object, 2)).toEqual([{a: 3}, {a: 4}]);
+       expect(pipe.transform(object, 10)).toEqual([]);
+     });
 });

--- a/test/collection/before-where.spec.pipe.ts
+++ b/test/collection/before-where.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { BeforeWherePipe } from '../../src/index';
+import {BeforeWherePipe} from '../../src/index';
 
 describe('BeforeWherePipe', () => {
   let pipe: BeforeWherePipe;
@@ -7,37 +7,35 @@ describe('BeforeWherePipe', () => {
   });
 
   it('should get array and properties object, and returns all the items,' +
-    'in the collection before the first that found with the given properties including it.', () => {
+         'in the collection before the first that found with the given properties including it.',
+     () => {
 
-      let array = [{ a: 1 }, { a: 2 }, { a: 3 }]
-        , orders = [
-          { id: 1, customer: { name: 'foo' }, date: 'Tue Jul 15 2014' },
-          { id: 2, customer: { name: 'foo' }, date: 'Tue Jul 16 2014' },
-          { id: 3, customer: { name: 'foo' }, date: 'Tue Jul 17 2014' },
-          { id: 4, customer: { name: 'foo' }, date: 'Tue Jul 18 2014' },
-          { id: 5, customer: { name: 'foo' }, date: 'Tue Jul 19 2014' }
-        ];
-      expect(pipe.transform(array, { a: 2 })).toEqual([{ a: 1 }, { a: 2 }]);
-      expect(pipe.transform(orders, { date: 'Tue Jul 17 2014' })).toEqual([orders[0], orders[1], orders[2]]);
-      expect(pipe.transform(orders, { date: 'Tue Jul 10 2014' })).toEqual(orders);
-    });
+       let array = [{a: 1}, {a: 2}, {a: 3}], orders = [
+         {id: 1, customer: {name: 'foo'}, date: 'Tue Jul 15 2014'},
+         {id: 2, customer: {name: 'foo'}, date: 'Tue Jul 16 2014'},
+         {id: 3, customer: {name: 'foo'}, date: 'Tue Jul 17 2014'},
+         {id: 4, customer: {name: 'foo'}, date: 'Tue Jul 18 2014'},
+         {id: 5, customer: {name: 'foo'}, date: 'Tue Jul 19 2014'}
+       ];
+       expect(pipe.transform(array, {a: 2})).toEqual([{a: 1}, {a: 2}]);
+       expect(pipe.transform(orders, {date: 'Tue Jul 17 2014'})).toEqual([
+         orders[0], orders[1], orders[2]
+       ]);
+       expect(pipe.transform(orders, {date: 'Tue Jul 10 2014'})).toEqual(orders);
+     });
 
   it('should get object and properties object, and returns all the items,' +
-    'in the collection before the first that found with the given properties including it.', () => {
+         'in the collection before the first that found with the given properties including it.',
+     () => {
 
-      let object = {
-        0: { a: 1 },
-        1: { a: 2 },
-        2: { a: 3 },
-        3: { a: 4 }
-      }, orders = {
-        0: { id: 1, customer: { name: 'foo' }, date: 'Tue Jul 15 2014' },
-        1: { id: 2, customer: { name: 'foo' }, date: 'Tue Jul 16 2014' },
-        2: { id: 3, customer: { name: 'foo' }, date: 'Tue Jul 17 2014' },
-        3: { id: 4, customer: { name: 'foo' }, date: 'Tue Jul 18 2014' },
-        4: { id: 5, customer: { name: 'foo' }, date: 'Tue Jul 19 2014' }
-      };
-      expect(pipe.transform(object, { a: 3 })).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }]);
-      expect(pipe.transform(orders, { date: 'Tue Jul 15 2014' })).toEqual([orders[0]]);
-    });
+       let object = {0: {a: 1}, 1: {a: 2}, 2: {a: 3}, 3: {a: 4}}, orders = {
+         0: {id: 1, customer: {name: 'foo'}, date: 'Tue Jul 15 2014'},
+         1: {id: 2, customer: {name: 'foo'}, date: 'Tue Jul 16 2014'},
+         2: {id: 3, customer: {name: 'foo'}, date: 'Tue Jul 17 2014'},
+         3: {id: 4, customer: {name: 'foo'}, date: 'Tue Jul 18 2014'},
+         4: {id: 5, customer: {name: 'foo'}, date: 'Tue Jul 19 2014'}
+       };
+       expect(pipe.transform(object, {a: 3})).toEqual([{a: 1}, {a: 2}, {a: 3}]);
+       expect(pipe.transform(orders, {date: 'Tue Jul 15 2014'})).toEqual([orders[0]]);
+     });
 });

--- a/test/collection/before.spec.pipe.ts
+++ b/test/collection/before.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { BeforePipe } from '../../src/index';
+import {BeforePipe} from '../../src/index';
 
 describe('BeforePipe', () => {
   let pipe: BeforePipe;
@@ -7,24 +7,20 @@ describe('BeforePipe', () => {
   });
 
   it('should get array as a collection and specified count, and returns all of the items' +
-    'in the collection before the specified count.', () => {
-      var array = [{ a: 1 }, { a: 2 }];
-      expect(pipe.transform(array, 2)).toEqual([{ a: 1 }]);
-      expect(pipe.transform([1, 2, 3, 4], 4)).toEqual([1, 2, 3]);
-      expect(pipe.transform([1, 2, 3, 4], 5)).toEqual([1, 2, 3, 4]);
-    });
-
+         'in the collection before the specified count.',
+     () => {
+       var array = [{a: 1}, {a: 2}];
+       expect(pipe.transform(array, 2)).toEqual([{a: 1}]);
+       expect(pipe.transform([1, 2, 3, 4], 4)).toEqual([1, 2, 3]);
+       expect(pipe.transform([1, 2, 3, 4], 5)).toEqual([1, 2, 3, 4]);
+     });
 
   it('should get object as a collection and specified count, and returns all of the items' +
-    'in the collection before the specified count.', () => {
-      var object = {
-        0: { a: 1 },
-        1: { a: 2 },
-        2: { a: 3 },
-        3: { a: 4 }
-      };
-      expect(pipe.transform(object, 3)).toEqual([{ a: 1 }, { a: 2 }]);
-      expect(pipe.transform(object, 1)).toEqual([]);
-      expect(pipe.transform(object, 10)).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }]);
-    });
+         'in the collection before the specified count.',
+     () => {
+       var object = {0: {a: 1}, 1: {a: 2}, 2: {a: 3}, 3: {a: 4}};
+       expect(pipe.transform(object, 3)).toEqual([{a: 1}, {a: 2}]);
+       expect(pipe.transform(object, 1)).toEqual([]);
+       expect(pipe.transform(object, 10)).toEqual([{a: 1}, {a: 2}, {a: 3}, {a: 4}]);
+     });
 });

--- a/test/collection/chunk-by.spec.pipe.ts
+++ b/test/collection/chunk-by.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { ChunkByPipe } from '../../src/index';
+import {ChunkByPipe} from '../../src/index';
 
 describe('ChunkByPipe', () => {
   let pipe: ChunkByPipe;

--- a/test/collection/concat.spec.pipe.ts
+++ b/test/collection/concat.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { ConcatPipe } from '../../src/index';
+import {ConcatPipe} from '../../src/index';
 
 describe('ConcatPipe', () => {
   let pipe: ConcatPipe;
@@ -10,15 +10,14 @@ describe('ConcatPipe', () => {
     expect(pipe.transform([1, 2, 3], [4, 5, 6])).toEqual([1, 2, 3, 4, 5, 6]);
     expect(pipe.transform([], [4, 5, 6])).toEqual([4, 5, 6]);
     expect(pipe.transform([true, false], [])).toEqual([true, false]);
-    expect(pipe.transform([{ a: 1 }], [{ a: 2 }])).toEqual([{ a: 1 }, { a: 2 }]);
+    expect(pipe.transform([{a: 1}], [{a: 2}])).toEqual([{a: 1}, {a: 2}]);
   });
 
   it('should get a mixed parameters and return merged collection', () => {
-    let array = [{ a: 1 }]
-      , object = { 0: { a: 2 }, 1: { a: 3 } };
-    expect(pipe.transform(array, object)).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }]);
-    expect(pipe.transform(object, array)).toEqual([{ a: 2 }, { a: 3 }, { a: 1 }]);
-    expect(pipe.transform(object, object)).toEqual([{ a: 2 }, { a: 3 }, { a: 2 }, { a: 3 }]);
-    expect(pipe.transform(array, array)).toEqual([{ a: 1 }, { a: 1 }]);
+    let array = [{a: 1}], object = {0: {a: 2}, 1: {a: 3}};
+    expect(pipe.transform(array, object)).toEqual([{a: 1}, {a: 2}, {a: 3}]);
+    expect(pipe.transform(object, array)).toEqual([{a: 2}, {a: 3}, {a: 1}]);
+    expect(pipe.transform(object, object)).toEqual([{a: 2}, {a: 3}, {a: 2}, {a: 3}]);
+    expect(pipe.transform(array, array)).toEqual([{a: 1}, {a: 1}]);
   });
 });

--- a/test/collection/contains.spec.pipe.ts
+++ b/test/collection/contains.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { ContainsPipe } from '../../src/index';
+import {ContainsPipe} from '../../src/index';
 
 describe('ContainsPipe', () => {
   let pipe: ContainsPipe;
@@ -28,15 +28,16 @@ describe('ContainsPipe', () => {
   });
 
   it('should get object as collection and return if given expression is ' +
-    'present in one or more object in the collection', function() {
-      var object = {
-        0: { id: 1, active: true },
-        1: { id: 2, active: false },
-        2: { id: 3, active: false },
-        3: { id: 4, active: false },
-      };
+         'present in one or more object in the collection',
+     function() {
+       var object = {
+         0: {id: 1, active: true},
+         1: {id: 2, active: false},
+         2: {id: 3, active: false},
+         3: {id: 4, active: false},
+       };
 
-      expect(pipe.transform(object, 'active')).toBeTruthy();
-      expect(pipe.transform(object, 'hello.world')).toBeFalsy();
-    });
+       expect(pipe.transform(object, 'active')).toBeTruthy();
+       expect(pipe.transform(object, 'hello.world')).toBeFalsy();
+     });
 });

--- a/test/collection/count-by.spec.pipe.ts
+++ b/test/collection/count-by.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { CountByPipe } from '../../src/index';
+import {CountByPipe} from '../../src/index';
 
 describe('CountByPipe', () => {
   let pipe: CountByPipe;
@@ -8,48 +8,28 @@ describe('CountByPipe', () => {
 
   it('should returns a count for the number of objects in each group.', function() {
     let players = [
-      { name: 'Gene', team: 'alpha' },
-      { name: 'George', team: 'beta' },
-      { name: 'Steve', team: 'gamma' },
-      { name: 'Paula', team: 'beta' },
-      { name: 'Scruath', team: 'gamma' }
+      {name: 'Gene', team: 'alpha'}, {name: 'George', team: 'beta'}, {name: 'Steve', team: 'gamma'},
+      {name: 'Paula', team: 'beta'}, {name: 'Scruath', team: 'gamma'}
     ];
-    expect(pipe.transform(players, 'team')).toEqual({
-      alpha: 1,
-      beta: 2,
-      gamma: 2
-    });
+    expect(pipe.transform(players, 'team')).toEqual({alpha: 1, beta: 2, gamma: 2});
   });
 
   it('should support nested properties to', function() {
     let orders = [
-      { id: 10, customer: { name: 'foo', id: 1 } },
-      { id: 11, customer: { name: 'bar', id: 2 } },
-      { id: 12, customer: { name: 'foo', id: 1 } },
-      { id: 13, customer: { name: 'bar', id: 2 } },
-      { id: 14, customer: { name: 'bar', id: 3 } },
-      2, null, true
+      {id: 10, customer: {name: 'foo', id: 1}}, {id: 11, customer: {name: 'bar', id: 2}},
+      {id: 12, customer: {name: 'foo', id: 1}}, {id: 13, customer: {name: 'bar', id: 2}},
+      {id: 14, customer: {name: 'bar', id: 3}}, 2, null, true
     ];
 
-    expect(pipe.transform(orders, 'customer.name')).toEqual({
-      foo: 2,
-      bar: 3,
-      undefined: 3
-    });
+    expect(pipe.transform(orders, 'customer.name')).toEqual({foo: 2, bar: 3, undefined: 3});
   });
 
   it('should get object as collection, property(nested to) as identifier and ' +
-    'returns the composed aggregate object.', function() {
-      let dataObject = {
-        0: { id: 1, data: {} },
-        1: { id: 1, data: {} },
-        2: { id: 2, data: {} },
-        3: { id: 2, data: {} }
-      };
+         'returns the composed aggregate object.',
+     function() {
+       let dataObject =
+           {0: {id: 1, data: {}}, 1: {id: 1, data: {}}, 2: {id: 2, data: {}}, 3: {id: 2, data: {}}};
 
-      expect(pipe.transform(dataObject, 'id')).toEqual({
-        1: 2,
-        2: 2
-      });
-    });
+       expect(pipe.transform(dataObject, 'id')).toEqual({1: 2, 2: 2});
+     });
 });

--- a/test/collection/defaults.spec.pipe.ts
+++ b/test/collection/defaults.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { DefaultsPipe } from '../../src/index';
+import {DefaultsPipe} from '../../src/index';
 
 describe('DefaultsPipe', () => {
   let pipe: DefaultsPipe;
@@ -7,29 +7,27 @@ describe('DefaultsPipe', () => {
   });
 
   it('should change the source object', function() {
-    var array = [{ a: 1 }];
-    var defaults = { b: 2 };
+    var array = [{a: 1}];
+    var defaults = {b: 2};
     var copy = array.map(o => Object.assign({}, o));
 
-    expect(pipe.transform(array, defaults)).toEqual([{ a: 1, b: 2 }]);
+    expect(pipe.transform(array, defaults)).toEqual([{a: 1, b: 2}]);
     expect(array).not.toEqual(copy);
   });
 
   describe('should use fallback value', function() {
     var expectOrders = [
-      { id: 1, destination: { zip: 21908 }, name: 'Ariel M.' },
-      { id: 2, destination: { zip: 'Pickup' }, name: 'John F.' },
-      { id: 3, destination: { zip: 45841 }, name: 'Not available' },
-      { id: 4, destination: { zip: 78612 }, name: 'Danno L.' }
+      {id: 1, destination: {zip: 21908}, name: 'Ariel M.'},
+      {id: 2, destination: {zip: 'Pickup'}, name: 'John F.'},
+      {id: 3, destination: {zip: 45841}, name: 'Not available'},
+      {id: 4, destination: {zip: 78612}, name: 'Danno L.'}
     ];
-    var defaults = { name: 'Not available', destination: { zip: 'Pickup' } };
+    var defaults = {name: 'Not available', destination: {zip: 'Pickup'}};
 
     it('should work with array', function() {
       var orders = [
-        { id: 1, destination: { zip: 21908 }, name: 'Ariel M.' },
-        { id: 2, name: 'John F.' },
-        { id: 3, destination: { zip: 45841 } },
-        { id: 4, destination: { zip: 78612 }, name: 'Danno L.' }
+        {id: 1, destination: {zip: 21908}, name: 'Ariel M.'}, {id: 2, name: 'John F.'},
+        {id: 3, destination: {zip: 45841}}, {id: 4, destination: {zip: 78612}, name: 'Danno L.'}
       ];
       var copyOrders = orders.map(o => Object.assign({}, o));
       expect(pipe.transform(copyOrders, defaults)).toEqual(expectOrders);
@@ -38,10 +36,10 @@ describe('DefaultsPipe', () => {
 
     it('should work with object', function() {
       var orders = {
-        0: { id: 1, destination: { zip: 21908 }, name: 'Ariel M.' },
-        1: { id: 2, name: 'John F.' },
-        2: { id: 3, destination: { zip: 45841 } },
-        3: { id: 4, destination: { zip: 78612 }, name: 'Danno L.' }
+        0: {id: 1, destination: {zip: 21908}, name: 'Ariel M.'},
+        1: {id: 2, name: 'John F.'},
+        2: {id: 3, destination: {zip: 45841}},
+        3: {id: 4, destination: {zip: 78612}, name: 'Danno L.'}
       };
       var copyOrders = Object.assign({}, orders);
 
@@ -51,16 +49,9 @@ describe('DefaultsPipe', () => {
   });
 
   it('should work fine with complex objects', function() {
-    let array = [
-      {
-        a: 'string',
-        b: { c: 1 },
-        d: { e: { f: new Function() } },
-        i: { j: { k: { l: 'm' } } }
-      }
-    ];
+    let array = [{a: 'string', b: {c: 1}, d: {e: {f: new Function()}}, i: {j: {k: {l: 'm'}}}}];
     var copy = array.map(o => Object.assign({}, o));
-    var defaults = { z: 'z', z1: { z2: 'z2' }, h: 1 };
+    var defaults = {z: 'z', z1: {z2: 'z2'}, h: 1};
     Object.assign(array[0], defaults);
     expect(pipe.transform(copy, defaults)).toEqual(array);
   });

--- a/test/collection/every.spec.pipe.ts
+++ b/test/collection/every.spec.pipe.ts
@@ -1,11 +1,10 @@
-import { EveryPipe } from '../../src/index';
+import {EveryPipe} from '../../src/index';
 
 describe('EveryPipe', () => {
   let pipe: EveryPipe;
   beforeEach(() => {
     pipe = new EveryPipe();
   });
-
 
   it('should get collection of primitives and use strict comparison(===)', function() {
     expect(pipe.transform(['bar', 'bar'], 'bar')).toBeTruthy();
@@ -15,18 +14,16 @@ describe('EveryPipe', () => {
   });
 
   it('should get array as collection and return if given expression is ' +
-    'present all members in the collection', function() {
+         'present all members in the collection',
+     function() {
 
-      var array = [
-        { id: 1, name: 'faa' },
-        { id: 1, name: 'baz' },
-        { id: 1, name: 'ariel' },
-        { id: 1, name: 'bar' }
-      ];
+       var array = [
+         {id: 1, name: 'faa'}, {id: 1, name: 'baz'}, {id: 1, name: 'ariel'}, {id: 1, name: 'bar'}
+       ];
 
-      expect(pipe.transform(array, 'id')).toBeTruthy();
-      expect(pipe.transform(array, 'foo')).toBeFalsy();
-    });
+       expect(pipe.transform(array, 'id')).toBeTruthy();
+       expect(pipe.transform(array, 'foo')).toBeFalsy();
+     });
 
   it('should get function as expression', function() {
     var array = [0, 2, 4, 6, 8];

--- a/test/collection/filter-by.spec.pipe.ts
+++ b/test/collection/filter-by.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { FilterByPipe } from '../../src/index';
+import {FilterByPipe} from '../../src/index';
 
 describe('FilterByPipe', () => {
   let pipe: FilterByPipe;
@@ -8,10 +8,10 @@ describe('FilterByPipe', () => {
 
   it('should pipe.transform by specific properties and avoid the rest', function() {
     var users = [
-      { id: 1, user: { first_name: 'foo', last_name: 'bar', mobile: 4444 } },
-      { id: 2, user: { first_name: 'bar', last_name: 'foo', mobile: 3333 } },
-      { id: 3, user: { first_name: 'foo', last_name: 'baz', mobile: 2222 } },
-      { id: 4, user: { first_name: 'baz', last_name: 'foo', mobile: 1111 } }
+      {id: 1, user: {first_name: 'foo', last_name: 'bar', mobile: 4444}},
+      {id: 2, user: {first_name: 'bar', last_name: 'foo', mobile: 3333}},
+      {id: 3, user: {first_name: 'foo', last_name: 'baz', mobile: 2222}},
+      {id: 4, user: {first_name: 'baz', last_name: 'foo', mobile: 1111}}
     ];
 
     expect(pipe.transform(users, ['user.first_name', 'user.last_name'], 'foo')).toEqual(users);
@@ -25,10 +25,10 @@ describe('FilterByPipe', () => {
 
   it('should support to get object as collection', function() {
     var users = {
-      0: { id: 1, user: { first_name: 'foo', last_name: 'bar', mobile: 4444 } },
-      1: { id: 2, user: { first_name: 'bar', last_name: 'foo', mobile: 3333 } },
-      2: { id: 3, user: { first_name: 'foo', last_name: 'baz', mobile: 2222 } },
-      3: { id: 4, user: { first_name: 'baz', last_name: 'foo', mobile: 1111 } }
+      0: {id: 1, user: {first_name: 'foo', last_name: 'bar', mobile: 4444}},
+      1: {id: 2, user: {first_name: 'bar', last_name: 'foo', mobile: 3333}},
+      2: {id: 3, user: {first_name: 'foo', last_name: 'baz', mobile: 2222}},
+      3: {id: 4, user: {first_name: 'baz', last_name: 'foo', mobile: 1111}}
     };
 
     expect(pipe.transform(users, ['user.first_name', 'user.last_name'], 'foo')).toEqual([
@@ -40,17 +40,25 @@ describe('FilterByPipe', () => {
 
   it('should parse concatenate properties, and search them by one field', function() {
     var users = [
-      { id: 1, user: { first_name: 'foo', last_name: 'bar', mobile: 4444 } },
-      { id: 2, user: { first_name: 'bar', last_name: 'foo', mobile: 3333 } },
-      { id: 3, user: { first_name: 'foo', last_name: 'baz', mobile: 2222 } },
-      { id: 4, user: { first_name: 'baz', last_name: 'foo', mobile: 1111 } }
+      {id: 1, user: {first_name: 'foo', last_name: 'bar', mobile: 4444}},
+      {id: 2, user: {first_name: 'bar', last_name: 'foo', mobile: 3333}},
+      {id: 3, user: {first_name: 'foo', last_name: 'baz', mobile: 2222}},
+      {id: 4, user: {first_name: 'baz', last_name: 'foo', mobile: 1111}}
     ];
 
-    expect(pipe.transform(users, ['user.first_name + user.last_name'], 'foo bar')).toEqual([users[0]]);
-    expect(pipe.transform(users, ['user.first_name+user.last_name'], 'foo bar')).toEqual([users[0]]);
-    expect(pipe.transform(users, ['user.first_name + user.mobile'], 'foo 4444')).toEqual([users[0]]);
+    expect(pipe.transform(users, ['user.first_name + user.last_name'], 'foo bar')).toEqual([
+      users[0]
+    ]);
+    expect(pipe.transform(users, ['user.first_name+user.last_name'], 'foo bar')).toEqual([
+      users[0]
+    ]);
+    expect(pipe.transform(users, ['user.first_name + user.mobile'], 'foo 4444')).toEqual([
+      users[0]
+    ]);
 
-    expect(pipe.transform(users, ['user.first_name + user.undefined'], 'foo')).toEqual([users[0], users[2]]);
+    expect(pipe.transform(users, ['user.first_name + user.undefined'], 'foo')).toEqual([
+      users[0], users[2]
+    ]);
 
     expect(pipe.transform(users, ['user.first_name + user.last_name'], 'a')).toEqual(users);
     expect(pipe.transform(users, ['user.first_name + user.last_name'], 'ba')).toEqual(users);
@@ -59,10 +67,10 @@ describe('FilterByPipe', () => {
 
   it('should take care on extreme conditions', function() {
     var users = [
-      { id: 1, user: { first_name: 'foo', last_name: 'bar', mobile: 4444 } },
-      { id: 2, user: { first_name: 'bar', last_name: 'foo', mobile: 3333 } },
-      { id: 3, user: { first_name: 'foo', last_name: 'baz', mobile: 2222 } },
-      { id: 4, user: { first_name: 'baz', last_name: 'foo', mobile: 1111 } }
+      {id: 1, user: {first_name: 'foo', last_name: 'bar', mobile: 4444}},
+      {id: 2, user: {first_name: 'bar', last_name: 'foo', mobile: 3333}},
+      {id: 3, user: {first_name: 'foo', last_name: 'baz', mobile: 2222}},
+      {id: 4, user: {first_name: 'baz', last_name: 'foo', mobile: 1111}}
     ];
 
     expect(pipe.transform(users, ['id'], 1)).toEqual([users[0]]);
@@ -74,9 +82,7 @@ describe('FilterByPipe', () => {
   });
 
   describe('strict mode', function() {
-    var users = [
-      { id: 1, user: { first_name: 'foo', last_name: 'bar', mobile: 4444 } }
-    ];
+    var users = [{id: 1, user: {first_name: 'foo', last_name: 'bar', mobile: 4444}}];
 
     it('should only return exact matches', function() {
       expect(pipe.transform(users, ['user.first_name'], 'fo', true)).toEqual([]);
@@ -85,12 +91,15 @@ describe('FilterByPipe', () => {
 
     it('should handle multiple properties', function() {
       expect(pipe.transform(users, ['user.first_name', 'user.last_name'], 'ba', true)).toEqual([]);
-      expect(pipe.transform(users, ['user.first_name', 'user.last_name'], 'bar', true)).toEqual(users);
+      expect(pipe.transform(users, ['user.first_name', 'user.last_name'], 'bar', true))
+          .toEqual(users);
     });
 
     it('should handle concatenation', function() {
-      expect(pipe.transform(users, ['user.first_name + user.last_name'], 'foo ba', true)).toEqual([]);
-      expect(pipe.transform(users, ['user.first_name + user.last_name'], 'foo bar', true)).toEqual(users);
+      expect(pipe.transform(users, ['user.first_name + user.last_name'], 'foo ba', true)).toEqual([
+      ]);
+      expect(pipe.transform(users, ['user.first_name + user.last_name'], 'foo bar', true))
+          .toEqual(users);
     });
   });
 });

--- a/test/collection/first.spec.pipe.ts
+++ b/test/collection/first.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { FirstPipe } from '../../src/index';
+import {FirstPipe} from '../../src/index';
 
 describe('FirstPipe', () => {
   let pipe: FirstPipe;
@@ -10,21 +10,21 @@ describe('FirstPipe', () => {
     expect(pipe.transform([1, 2, 3, 4, 5])).toEqual(1);
     expect(pipe.transform(['a', 'b', 'c', 'd'])).toEqual('a');
     expect(pipe.transform([undefined, null, null])).toEqual(undefined);
-    expect(pipe.transform({ 0: 'foo', 1: 'bar' })).toEqual('foo');
+    expect(pipe.transform({0: 'foo', 1: 'bar'})).toEqual('foo');
   });
 
   it('should return first n elements of a collection', function() {
     expect(pipe.transform([1, 2, 3, 4, 5], 3)).toEqual([1, 2, 3]);
     expect(pipe.transform([undefined, null, null], 1)).toEqual([undefined]);
-    expect(pipe.transform({ 0: 'foo', 1: 'bar' }, 2)).toEqual(['foo', 'bar']);
+    expect(pipe.transform({0: 'foo', 1: 'bar'}, 2)).toEqual(['foo', 'bar']);
   });
 
   it('should return the first element that match the expression', function() {
     var users = [
-      { id: 1, name: { first: 'foo', last: 'bar' }, active: false },
-      { id: 2, name: { first: 'baz', last: 'bar' }, active: true },
-      { id: 3, name: { first: 'bar', last: 'bar' }, active: false },
-      { id: 4, name: { first: 'lol', last: 'bar' }, active: true }
+      {id: 1, name: {first: 'foo', last: 'bar'}, active: false},
+      {id: 2, name: {first: 'baz', last: 'bar'}, active: true},
+      {id: 3, name: {first: 'bar', last: 'bar'}, active: false},
+      {id: 4, name: {first: 'lol', last: 'bar'}, active: true}
     ];
 
     expect(pipe.transform(users, 'active')).toEqual([users[1]]);

--- a/test/collection/flatten.spec.pipe.ts
+++ b/test/collection/flatten.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { FlattenPipe } from '../../src/index';
+import {FlattenPipe} from '../../src/index';
 
 describe('FlattenPipe', () => {
   let pipe: FlattenPipe;
@@ -9,27 +9,30 @@ describe('FlattenPipe', () => {
   it('should get a multiple nested array and return it flatten', function() {
     expect(pipe.transform([[[[[0]]]]])).toEqual([0]);
 
-    expect(pipe.transform([[], 'A', 'B', ['C', 'D'], ['E', ['F'], []]]))
-      .toEqual(['A', 'B', 'C', 'D', 'E', 'F']);
+    expect(pipe.transform([[], 'A', 'B', ['C', 'D'], ['E', ['F'], []]])).toEqual([
+      'A', 'B', 'C', 'D', 'E', 'F'
+    ]);
 
-    expect(pipe.transform([[[[null]]], [[null]], [null]]))
-      .toEqual([null, null, null]);
+    expect(pipe.transform([[[[null]]], [[null]], [null]])).toEqual([null, null, null]);
 
-    expect(pipe.transform([[], 1, 2, 3, [4, 5, 6, [7, 8, 9, [10, 11, [12, [[[[[13], [[[[14, 15]]]]]]]]]]]]]))
-      .toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
+    expect(pipe.transform([
+      [], 1, 2, 3, [4, 5, 6, [7, 8, 9, [10, 11, [12, [[[[[13], [[[[14, 15]]]]]]]]]]]]
+    ])).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
   });
 
   it('should have ability to get object as a collection', function() {
-    expect(pipe.transform({ 0: 1, 1: 2, 2: [3, 4], 3: [5, [6, 7, [8]]] }))
-      .toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
-    expect(pipe.transform({}))
-      .toEqual([]);
+    expect(pipe.transform({0: 1, 1: 2, 2: [3, 4], 3: [5, [6, 7, [8]]]})).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8
+    ]);
+    expect(pipe.transform({})).toEqual([]);
   });
 
   it('should flattened a single level, if shallow set to true', function() {
-    expect(pipe.transform(['out', ['out', ['in']], ['out', 'out', ['in', 'in']], ['out', 'out']], true))
-      .toEqual(['out', 'out', ['in'], 'out', 'out', ['in', 'in'], 'out', 'out']);
-    expect(pipe.transform([[], 1, [1, [0, [0, [0]]], 1, [0]], 1, [1, [0]]], true))
-      .toEqual([1, 1, [0, [0, [0]]], 1, [0], 1, 1, [0]]);
+    expect(pipe.transform(
+               ['out', ['out', ['in']], ['out', 'out', ['in', 'in']], ['out', 'out']], true))
+        .toEqual(['out', 'out', ['in'], 'out', 'out', ['in', 'in'], 'out', 'out']);
+    expect(pipe.transform([[], 1, [1, [0, [0, [0]]], 1, [0]], 1, [1, [0]]], true)).toEqual([
+      1, 1, [0, [0, [0]]], 1, [0], 1, 1, [0]
+    ]);
   });
 });

--- a/test/collection/fuzzy-by.spec.pipe.ts
+++ b/test/collection/fuzzy-by.spec.pipe.ts
@@ -1,23 +1,20 @@
-import { FuzzyByPipe } from '../../src/index';
+import {FuzzyByPipe} from '../../src/index';
 
 describe('FuzzyByPipe', () => {
-  let pipe: FuzzyByPipe
-    , collection = [
-      { title: 'The DaVinci Code' },
-      { title: 'The Great Gatsby' },
-      { title: 'Angels & Demons' },
-      { title: 'The Lost Symbol' },
-      { title: 'Old Man\'s War' }
-    ];
+  let pipe: FuzzyByPipe, collection = [
+    {title: 'The DaVinci Code'}, {title: 'The Great Gatsby'}, {title: 'Angels & Demons'},
+    {title: 'The Lost Symbol'}, {title: 'Old Man\'s War'}
+  ];
   beforeEach(() => {
     pipe = new FuzzyByPipe();
   });
 
-  it('should get array as collection, property, search, and pipe.transform by fuzzy searching', function() {
-    expect(pipe.transform(collection, 'title', 'tha')).toEqual([collection[0], collection[1]]);
-    expect(pipe.transform(collection, 'title', 'thesy')).toEqual([collection[1], collection[3]]);
-    expect(pipe.transform(collection, 'title', 'omwar')).toEqual([collection[4]]);
-  });
+  it('should get array as collection, property, search, and pipe.transform by fuzzy searching',
+     function() {
+       expect(pipe.transform(collection, 'title', 'tha')).toEqual([collection[0], collection[1]]);
+       expect(pipe.transform(collection, 'title', 'thesy')).toEqual([collection[1], collection[3]]);
+       expect(pipe.transform(collection, 'title', 'omwar')).toEqual([collection[4]]);
+     });
 
   it('should be case sensitive if set to true', function() {
     expect(pipe.transform(collection, 'title', 'tha', true)).toEqual([]);
@@ -31,15 +28,17 @@ describe('FuzzyByPipe', () => {
 
   it('should support nested properties', function() {
     let collection = [
-      { details: { title: 'The DaVinci Code' } },
-      { details: { title: 'The Great Gatsby' } },
-      { details: { title: 'Angels & Demons' } },
-      { details: { title: 'The Lost Symbol' } },
-      { details: { title: 'Old Man\'s War' } }
+      {details: {title: 'The DaVinci Code'}}, {details: {title: 'The Great Gatsby'}},
+      {details: {title: 'Angels & Demons'}}, {details: {title: 'The Lost Symbol'}},
+      {details: {title: 'Old Man\'s War'}}
     ];
 
-    expect(pipe.transform(collection, 'details.title', 'tha')).toEqual([collection[0], collection[1]]);
-    expect(pipe.transform(collection, 'details.title', 'thesy')).toEqual([collection[1], collection[3]]);
+    expect(pipe.transform(collection, 'details.title', 'tha')).toEqual([
+      collection[0], collection[1]
+    ]);
+    expect(pipe.transform(collection, 'details.title', 'thesy')).toEqual([
+      collection[1], collection[3]
+    ]);
     expect(pipe.transform(collection, 'details.title', 'omwar')).toEqual([collection[4]]);
   });
 });

--- a/test/collection/fuzzy.spec.pipe.ts
+++ b/test/collection/fuzzy.spec.pipe.ts
@@ -1,25 +1,24 @@
-import { FuzzyPipe } from '../../src/index';
+import {FuzzyPipe} from '../../src/index';
 
 describe('FuzzyPipe', () => {
-  let pipe: FuzzyPipe
-    , collection = [
-      { title: 'The DaVinci Code', author: 'F. Scott Fitzgerald' },
-      { title: 'The Great Gatsby', author: 'Dan Browns' },
-      { title: 'Angels & Demons', author: 'Dan Louis' },
-      { title: 'The Lost Symbol', author: 'David Maine' },
-      { title: 'Old Man\'s War', author: 'Rob Grant' }
-    ];
+  let pipe: FuzzyPipe, collection = [
+    {title: 'The DaVinci Code', author: 'F. Scott Fitzgerald'},
+    {title: 'The Great Gatsby', author: 'Dan Browns'},
+    {title: 'Angels & Demons', author: 'Dan Louis'},
+    {title: 'The Lost Symbol', author: 'David Maine'},
+    {title: 'Old Man\'s War', author: 'Rob Grant'}
+  ];
   beforeEach(() => {
     pipe = new FuzzyPipe();
   });
 
   it('should get array as collection, search, and pipe.transform by fuzzy searching', function() {
-    //search by title
+    // search by title
     expect(pipe.transform(collection, 'tha')).toEqual([collection[0], collection[1]]);
     expect(pipe.transform(collection, 'thesy')).toEqual([collection[1], collection[3]]);
     expect(pipe.transform(collection, 'omwar')).toEqual([collection[4]]);
 
-    //search by author
+    // search by author
     expect(pipe.transform(collection, 'sfd')).toEqual([collection[0]]);
     expect(pipe.transform(collection, 'danos')).toEqual([collection[1], collection[2]]);
     expect(pipe.transform(collection, 'rgnt')).toEqual([collection[4]]);

--- a/test/collection/group-by.spec.pipe.ts
+++ b/test/collection/group-by.spec.pipe.ts
@@ -1,37 +1,34 @@
-import { GroupByPipe } from '../../src/index';
+import {GroupByPipe} from '../../src/index';
 
 describe('GroupByPipe', () => {
-  let pipe: GroupByPipe;;
+  let pipe: GroupByPipe;
+  ;
   beforeEach(() => {
     pipe = new GroupByPipe();
   });
 
   it('should get array as collection, property(nested to) as identifier and ' +
-    'returns the composed aggregate object.', function() {
+         'returns the composed aggregate object.',
+     function() {
 
-      var players = [
-        { name: 'Gene', team: 'alpha' },
-        { name: 'George', team: 'beta' },
-        { name: 'Steve', team: 'gamma' },
-        { name: 'Paula', team: 'beta' },
-        { name: 'Scruath', team: 'gamma' }
-      ];
+       var players = [
+         {name: 'Gene', team: 'alpha'}, {name: 'George', team: 'beta'},
+         {name: 'Steve', team: 'gamma'}, {name: 'Paula', team: 'beta'},
+         {name: 'Scruath', team: 'gamma'}
+       ];
 
-      expect(pipe.transform(players, 'team')).toEqual({
-        alpha: [players[0]],
-        beta: [players[1], players[3]],
-        gamma: [players[2], players[4]]
-      });
-    });
+       expect(pipe.transform(players, 'team')).toEqual({
+         alpha: [players[0]],
+         beta: [players[1], players[3]],
+         gamma: [players[2], players[4]]
+       });
+     });
 
   it('should support nested properties to', function() {
     var orders = [
-      { id: 10, customer: { name: 'foo', id: 1 } },
-      { id: 11, customer: { name: 'bar', id: 2 } },
-      { id: 12, customer: { name: 'foo', id: 1 } },
-      { id: 13, customer: { name: 'bar', id: 2 } },
-      { id: 14, customer: { name: 'bar', id: 3 } },
-      2, null, true
+      {id: 10, customer: {name: 'foo', id: 1}}, {id: 11, customer: {name: 'bar', id: 2}},
+      {id: 12, customer: {name: 'foo', id: 1}}, {id: 13, customer: {name: 'bar', id: 2}},
+      {id: 14, customer: {name: 'bar', id: 3}}, 2, null, true
     ];
 
     expect(pipe.transform(orders, 'customer.name')).toEqual({
@@ -41,19 +38,13 @@ describe('GroupByPipe', () => {
     });
   });
 
-
   it('should get object as collection, property(nested to) as identifier and ' +
-    'returns the composed aggregate object.', function() {
-      var dataObject = {
-        0: { id: 1, data: {} },
-        1: { id: 1, data: {} },
-        2: { id: 2, data: {} },
-        3: { id: 2, data: {} }
-      };
+         'returns the composed aggregate object.',
+     function() {
+       var dataObject =
+           {0: {id: 1, data: {}}, 1: {id: 1, data: {}}, 2: {id: 2, data: {}}, 3: {id: 2, data: {}}};
 
-      expect(pipe.transform(dataObject, 'id')).toEqual({
-        1: [dataObject[0], dataObject[1]],
-        2: [dataObject[2], dataObject[3]]
-      });
-    });
+       expect(pipe.transform(dataObject, 'id'))
+           .toEqual({1: [dataObject[0], dataObject[1]], 2: [dataObject[2], dataObject[3]]});
+     });
 });

--- a/test/collection/is-empty.spec.pipe.ts
+++ b/test/collection/is-empty.spec.pipe.ts
@@ -1,13 +1,14 @@
-import { IsEmptyPipe } from '../../src/index';
+import {IsEmptyPipe} from '../../src/index';
 
 describe('IsEmptyPipe', () => {
-  let pipe: IsEmptyPipe;;
+  let pipe: IsEmptyPipe;
+  ;
   beforeEach(() => {
     pipe = new IsEmptyPipe();
   });
 
   it('length of collection', function() {
     expect(pipe.transform([1, 2, 3])).toEqual(3);
-    expect(pipe.transform({ 0: 'a', 1: 'b', 2: 'c' })).toEqual(3);
+    expect(pipe.transform({0: 'a', 1: 'b', 2: 'c'})).toEqual(3);
   });
 });

--- a/test/collection/join.spec.pipe.ts
+++ b/test/collection/join.spec.pipe.ts
@@ -1,7 +1,8 @@
-import { JoinPipe } from '../../src/index';
+import {JoinPipe} from '../../src/index';
 
 describe('JoinPipe', () => {
-  let pipe: JoinPipe;;
+  let pipe: JoinPipe;
+  ;
   beforeEach(() => {
     pipe = new JoinPipe();
   });
@@ -42,8 +43,12 @@ describe('JoinPipe', () => {
             delim = 10;
             expect(pipe.transform(arr, delim)).toEqual('hello10world');
 
-            delim = { toString: function() { return ' - ' } }
-            expect(pipe.transform(arr, delim)).toEqual('hello - world');
+            delim = {
+              toString: function() {
+                return ' - '
+              }
+            } expect(pipe.transform(arr, delim))
+                        .toEqual('hello - world');
           });
         });
 

--- a/test/collection/join.spec.pipe.ts
+++ b/test/collection/join.spec.pipe.ts
@@ -47,8 +47,8 @@ describe('JoinPipe', () => {
               toString: function() {
                 return ' - '
               }
-            } expect(pipe.transform(arr, delim))
-                        .toEqual('hello - world');
+            };
+            expect(pipe.transform(arr, delim)).toEqual('hello - world');
           });
         });
 

--- a/test/collection/last.spec.pipe.ts
+++ b/test/collection/last.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { LastPipe } from '../../src/index';
+import {LastPipe} from '../../src/index';
 
 describe('LastPipe', () => {
   let pipe: LastPipe;
@@ -10,21 +10,21 @@ describe('LastPipe', () => {
     expect(pipe.transform([1, 2, 3, 4, 5])).toEqual(5);
     expect(pipe.transform(['a', 'b', 'c', 'd'])).toEqual('d');
     expect(pipe.transform([undefined, null, null])).toEqual(null);
-    expect(pipe.transform({ 0: 'foo', 1: 'bar' })).toEqual('bar');
+    expect(pipe.transform({0: 'foo', 1: 'bar'})).toEqual('bar');
   });
 
   it('should return last n elements of a collection', function() {
     expect(pipe.transform([1, 2, 3, 4, 5], 3)).toEqual([3, 4, 5]);
     expect(pipe.transform([undefined, null, null], 2)).toEqual([null, null]);
-    expect(pipe.transform({ 0: 'foo', 1: 'bar' }, 2)).toEqual(['foo', 'bar']);
+    expect(pipe.transform({0: 'foo', 1: 'bar'}, 2)).toEqual(['foo', 'bar']);
   });
 
   it('should return the last element that match the expression', function() {
     var users = [
-      { id: 1, name: { first: 'foo', last: 'bar' }, active: false },
-      { id: 2, name: { first: 'baz', last: 'bar' }, active: true },
-      { id: 3, name: { first: 'bar', last: 'bar' }, active: false },
-      { id: 4, name: { first: 'lol', last: 'bar' }, active: true }
+      {id: 1, name: {first: 'foo', last: 'bar'}, active: false},
+      {id: 2, name: {first: 'baz', last: 'bar'}, active: true},
+      {id: 3, name: {first: 'bar', last: 'bar'}, active: false},
+      {id: 4, name: {first: 'lol', last: 'bar'}, active: true}
     ];
 
     expect(pipe.transform(users, 'active')).toEqual([users[3]]);

--- a/test/collection/map.spec.pipe.ts
+++ b/test/collection/map.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { MapPipe } from '../../src/index';
+import {MapPipe} from '../../src/index';
 
 describe('MapPipe', () => {
   let pipe: MapPipe;
@@ -8,18 +8,12 @@ describe('MapPipe', () => {
 
   it('should returns a new collection of the results of each expression execution', function() {
 
-    var array = [
-      { id: 1, name: 'foo' },
-      { id: 2, name: 'baz' },
-      { id: 1, name: 'ariel' },
-      { id: 1, name: 'bar' }
-    ];
+    var array =
+        [{id: 1, name: 'foo'}, {id: 2, name: 'baz'}, {id: 1, name: 'ariel'}, {id: 1, name: 'bar'}];
     expect(pipe.transform(array, 'name')).toEqual(['foo', 'baz', 'ariel', 'bar']);
   });
 
-
   it('should return the last n element that match the expression', function() {
-    expect(pipe.transform([1, 2, 3, 4, 5, 6], (e: number) => e * 2))
-      .toEqual([2, 4, 6, 8, 10, 12]);
+    expect(pipe.transform([1, 2, 3, 4, 5, 6], (e: number) => e * 2)).toEqual([2, 4, 6, 8, 10, 12]);
   });
 });

--- a/test/collection/omit.spec.pipe.ts
+++ b/test/collection/omit.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { OmitPipe } from '../../src/index';
+import {OmitPipe} from '../../src/index';
 
 describe('OmitPipe', () => {
   let pipe: OmitPipe;
@@ -9,14 +9,11 @@ describe('OmitPipe', () => {
   it('should returns a new collection of the results of each expression execution', function() {
 
     var array = [
-      { id: 1, name: 'foo', active: true },
-      { id: 2, name: 'baz', active: true },
-      { id: 1, name: 'ariel', active: true },
-      { id: 1, name: 'bar', active: false }
+      {id: 1, name: 'foo', active: true}, {id: 2, name: 'baz', active: true},
+      {id: 1, name: 'ariel', active: true}, {id: 1, name: 'bar', active: false}
     ];
     expect(pipe.transform(array, 'active')).toEqual([array[3]]);
   });
-
 
   it('should omit elements that match the expression', function() {
     expect(pipe.transform([1, 2, 3, 4, 5, 6], (e: number) => e > 2)).toEqual([1, 2]);

--- a/test/collection/order-by.spec.pipe.ts
+++ b/test/collection/order-by.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { OrderByPipe } from '../../src/index';
+import {OrderByPipe} from '../../src/index';
 
 describe('OrderByPipe', () => {
   let pipe: OrderByPipe;
@@ -8,29 +8,36 @@ describe('OrderByPipe', () => {
 
   it('should sort objects be the given attrs', function() {
     let games = [
-      { name: 'Pako', rating: 4.21 },
-      { name: 'Hill Climb Racing', rating: 3.87 },
-      { name: 'Angry Birds Space', rating: 3.88 },
-      { name: 'Badland', rating: 4.33 }
+      {name: 'Pako', rating: 4.21}, {name: 'Hill Climb Racing', rating: 3.87},
+      {name: 'Angry Birds Space', rating: 3.88}, {name: 'Badland', rating: 4.33}
     ];
 
     expect(pipe.transform(games, 'name')).toEqual([
-      games[2], games[3], games[1], games[0],
+      games[2],
+      games[3],
+      games[1],
+      games[0],
     ]);
 
     expect(pipe.transform(games, 'rating')).toEqual([
-      games[1], games[2], games[0], games[3],
+      games[1],
+      games[2],
+      games[0],
+      games[3],
     ]);
 
     expect(pipe.transform(games, '-rating')).toEqual([
-      games[3], games[0], games[2], games[1],
+      games[3],
+      games[0],
+      games[2],
+      games[1],
     ]);
   });
 
   it('should support multiple attr', function() {
     let users = [
-      { name: 'Ariel', age: 20 },
-      { name: 'Bar', age: 20 },
+      {name: 'Ariel', age: 20},
+      {name: 'Bar', age: 20},
     ];
     expect(pipe.transform(users, 'age', '-name')).toEqual(users.reverse());
   });

--- a/test/collection/pick.spec.pipe.ts
+++ b/test/collection/pick.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { PickPipe } from '../../src/index';
+import {PickPipe} from '../../src/index';
 
 describe('PickPipe', () => {
   let pipe: PickPipe;
@@ -9,14 +9,11 @@ describe('PickPipe', () => {
   it('should returns a new collection of the results of each expression execution', function() {
 
     var array = [
-      { id: 1, name: 'foo', active: true },
-      { id: 2, name: 'baz', active: true },
-      { id: 1, name: 'ariel', active: true },
-      { id: 1, name: 'bar', active: false }
+      {id: 1, name: 'foo', active: true}, {id: 2, name: 'baz', active: true},
+      {id: 1, name: 'ariel', active: true}, {id: 1, name: 'bar', active: false}
     ];
     expect(pipe.transform(array, 'active')).toEqual([array[0], array[1], array[2]]);
   });
-
 
   it('should omit elements that match the expression', function() {
     expect(pipe.transform([1, 2, 3, 4, 5, 6], (e: number) => e <= 2)).toEqual([1, 2]);

--- a/test/collection/range.spec.pipe.ts
+++ b/test/collection/range.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { RangePipe } from '../../src/index';
+import {RangePipe} from '../../src/index';
 
 describe('RangePipe', () => {
   let pipe: RangePipe;
@@ -22,8 +22,9 @@ describe('RangePipe', () => {
   });
 
   it('should return 10 items starting at 10 incrementing by 10 and multiplied by 2.', function() {
-    expect(pipe.transform([], 10, 10, 10, function(n: number) { return 2 * n; }))
-      .toEqual([20, 40, 60, 80, 100, 120, 140, 160, 180, 200]);
+    expect(pipe.transform([], 10, 10, 10, function(n: number) {
+      return 2 * n;
+    })).toEqual([20, 40, 60, 80, 100, 120, 140, 160, 180, 200]);
     expect(pipe.transform([], 10).length).toEqual(10);
   });
 });

--- a/test/collection/remove-with.spec.pipe.ts
+++ b/test/collection/remove-with.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { RemoveWithPipe } from '../../src/index';
+import {RemoveWithPipe} from '../../src/index';
 
 describe('RemoveWithPipe', () => {
   let pipe: RemoveWithPipe;
@@ -7,43 +7,45 @@ describe('RemoveWithPipe', () => {
   });
 
   it('should get array and properties object and return' +
-    'array pipe.transformed by equivalent property values.', function() {
+         'array pipe.transformed by equivalent property values.',
+     function() {
 
-      var array = [
-        { id: 1, name: 'ariel' },
-        { id: 2, name: 'baz' },
-        { id: 1, name: 'ariel' },
-        { id: 1, name: 'bar' }
-      ];
+       var array = [
+         {id: 1, name: 'ariel'}, {id: 2, name: 'baz'}, {id: 1, name: 'ariel'},
+         {id: 1, name: 'bar'}
+       ];
 
-      expect(pipe.transform(array, { id: 1 })).toEqual([{ id: 2, name: 'baz' }]);
-      expect(pipe.transform(array, { id: 1, name: 'ariel' })).toEqual([{ id: 2, name: 'baz' }, { id: 1, name: 'bar' }]);
+       expect(pipe.transform(array, {id: 1})).toEqual([{id: 2, name: 'baz'}]);
+       expect(pipe.transform(array, {id: 1, name: 'ariel'})).toEqual([
+         {id: 2, name: 'baz'}, {id: 1, name: 'bar'}
+       ]);
 
-      expect(pipe.transform(array, {})).toEqual([]);
+       expect(pipe.transform(array, {})).toEqual([]);
 
-    });
+     });
 
   it('should get object and properties object and return' +
-    'array of all elements that have equivalent property values.', function() {
+         'array of all elements that have equivalent property values.',
+     function() {
 
-      var object = {
-        0: { id: 1, name: 'ariel' },
-        1: { id: 2, name: 'baz' },
-        2: { id: 1, name: 'ariel' },
-        3: { id: 1, name: 'bar' }
-      };
+       var object = {
+         0: {id: 1, name: 'ariel'},
+         1: {id: 2, name: 'baz'},
+         2: {id: 1, name: 'ariel'},
+         3: {id: 1, name: 'bar'}
+       };
 
-      expect(pipe.transform(object, { id: 1 })).toEqual([object[1]]);
-      expect(pipe.transform(object, { id: 1, name: 'ariel' })).not.toContain(object[0]);
+       expect(pipe.transform(object, {id: 1})).toEqual([object[1]]);
+       expect(pipe.transform(object, {id: 1, name: 'ariel'})).not.toContain(object[0]);
 
-      expect(pipe.transform(object, {}).length).toEqual(0);
+       expect(pipe.transform(object, {}).length).toEqual(0);
 
-    });
+     });
 
   it('should not get properties object and return the collection as is', function() {
 
-    expect(pipe.transform([{ a: 1 }])).toEqual([{ a: 1 }]);
-    expect(pipe.transform([{ a: 1 }, { b: 2 }])).toEqual([{ a: 1 }, { b: 2 }]);
+    expect(pipe.transform([{a: 1}])).toEqual([{a: 1}]);
+    expect(pipe.transform([{a: 1}, {b: 2}])).toEqual([{a: 1}, {b: 2}]);
 
   });
 });

--- a/test/collection/remove.spec.pipe.ts
+++ b/test/collection/remove.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { RemovePipe } from '../../src/index';
+import {RemovePipe} from '../../src/index';
 
 describe('RemovePipe', () => {
   let pipe: RemovePipe;

--- a/test/collection/reverse.spec.pipe.ts
+++ b/test/collection/reverse.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { ReversePipe } from '../../src/index';
+import {ReversePipe} from '../../src/index';
 
 describe('RemoveWithPipe', () => {
   let pipe: ReversePipe;

--- a/test/collection/search-field.spec.pipe.ts
+++ b/test/collection/search-field.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { SearchFieldPipe } from '../../src/index';
+import {SearchFieldPipe} from '../../src/index';
 
 describe('SearchFieldPipe', () => {
   let pipe: SearchFieldPipe;
@@ -7,55 +7,62 @@ describe('SearchFieldPipe', () => {
   });
 
   it('should get array as a collection, and several keys for searchFiled and' +
-    'return new array with the new "searchField" property', function() {
+         'return new array with the new "searchField" property',
+     function() {
 
-      var input = [
-        { first_name: 'Sharon', last_name: 'Melendez' },
-        { first_name: 'Edmundo', last_name: 'Hepler' },
-        { first_name: 'Marsha', last_name: 'Letourneau' }
-      ];
+       var input = [
+         {first_name: 'Sharon', last_name: 'Melendez'},
+         {first_name: 'Edmundo', last_name: 'Hepler'},
+         {first_name: 'Marsha', last_name: 'Letourneau'}
+       ];
 
-      var output = [
-        { first_name: 'Sharon', last_name: 'Melendez', searchField: 'Sharon Melendez' },
-        { first_name: 'Edmundo', last_name: 'Hepler', searchField: 'Edmundo Hepler' },
-        { first_name: 'Marsha', last_name: 'Letourneau', searchField: 'Marsha Letourneau' }
-      ];
+       var output = [
+         {first_name: 'Sharon', last_name: 'Melendez', searchField: 'Sharon Melendez'},
+         {first_name: 'Edmundo', last_name: 'Hepler', searchField: 'Edmundo Hepler'},
+         {first_name: 'Marsha', last_name: 'Letourneau', searchField: 'Marsha Letourneau'}
+       ];
 
-      expect(pipe.transform(input, 'first_name', 'last_name')).toEqual(output);
+       expect(pipe.transform(input, 'first_name', 'last_name')).toEqual(output);
 
-      expect(pipe.transform([{ a: 'a', b: 'b' }], 'a', 'b')).toEqual([{ a: 'a', b: 'b', searchField: 'a b' }]);
+       expect(pipe.transform([{a: 'a', b: 'b'}], 'a', 'b')).toEqual([
+         {a: 'a', b: 'b', searchField: 'a b'}
+       ]);
 
-    });
+     });
 
   it('should support nested properties to', function() {
 
     var input = [
-      { user: { first_name: 'Sharon', last_name: 'Melendez' } },
-      { user: { first_name: 'Edmundo', last_name: 'Hepler' } },
-      { user: { first_name: 'Marsha', last_name: 'Letourneau' } }
+      {user: {first_name: 'Sharon', last_name: 'Melendez'}},
+      {user: {first_name: 'Edmundo', last_name: 'Hepler'}},
+      {user: {first_name: 'Marsha', last_name: 'Letourneau'}}
     ];
 
     var output = [
-      { user: { first_name: 'Sharon', last_name: 'Melendez' }, searchField: 'Sharon Melendez' },
-      { user: { first_name: 'Edmundo', last_name: 'Hepler' }, searchField: 'Edmundo Hepler' },
-      { user: { first_name: 'Marsha', last_name: 'Letourneau' }, searchField: 'Marsha Letourneau' }
+      {user: {first_name: 'Sharon', last_name: 'Melendez'}, searchField: 'Sharon Melendez'},
+      {user: {first_name: 'Edmundo', last_name: 'Hepler'}, searchField: 'Edmundo Hepler'},
+      {user: {first_name: 'Marsha', last_name: 'Letourneau'}, searchField: 'Marsha Letourneau'}
     ];
 
-    var inputObject = { user: { details: { name: { first: 'Ariel', last: 'Mashraki' } } } },
-      outputObject = { user: { details: { name: { first: 'Ariel', last: 'Mashraki' } } }, searchField: 'Ariel Mashraki' };
+    var inputObject = {user: {details: {name: {first: 'Ariel', last: 'Mashraki'}}}},
+        outputObject = {
+          user: {details: {name: {first: 'Ariel', last: 'Mashraki'}}},
+          searchField: 'Ariel Mashraki'
+        };
 
     expect(pipe.transform(input, 'user.first_name', 'user.last_name')).toEqual(output);
 
-    expect(pipe.transform([inputObject], 'user.details.name.first', 'user.details.name.last')).toEqual([outputObject]);
+    expect(pipe.transform([inputObject], 'user.details.name.first', 'user.details.name.last'))
+        .toEqual([outputObject]);
 
   });
 
   it('should change the original/source collection', function() {
 
-    var mutable = [{ a: 'a', b: 'b' }];
+    var mutable = [{a: 'a', b: 'b'}];
     pipe.transform(mutable, 'a', 'b');
 
-    expect(mutable).toEqual([{ a: 'a', b: 'b', searchField: 'a b' }]);
+    expect(mutable).toEqual([{a: 'a', b: 'b', searchField: 'a b'}]);
 
   });
 });

--- a/test/collection/to-array.spec.pipe.ts
+++ b/test/collection/to-array.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { ToArrayPipe } from '../../src/index';
+import {ToArrayPipe} from '../../src/index';
 
 describe('ToArrayPipe', () => {
   let pipe: ToArrayPipe;
@@ -7,25 +7,15 @@ describe('ToArrayPipe', () => {
   });
 
   it('should convert an object to an array of values', function() {
-    var object = {
-      0: { f: 'foo' },
-      1: { b: 'bar' },
-      2: { b: 'baz' }
-    };
+    var object = {0: {f: 'foo'}, 1: {b: 'bar'}, 2: {b: 'baz'}};
     expect(pipe.transform(object)).toEqual([object[0], object[1], object[2]]);
-    expect(pipe.transform({ 0: 0, 1: 1, 2: 2 })).toEqual([0, 1, 2]);
+    expect(pipe.transform({0: 0, 1: 1, 2: 2})).toEqual([0, 1, 2]);
   });
 
   it('should add $key property if addKey param is true', function() {
-    var object = {
-      0: { f: 'foo' },
-      1: { b: 'bar' },
-      2: { b: 'baz' }
-    };
+    var object = {0: {f: 'foo'}, 1: {b: 'bar'}, 2: {b: 'baz'}};
     expect(pipe.transform(object, true)).toEqual([
-      { $key: '0', f: 'foo' },
-      { $key: '1', b: 'bar' },
-      { $key: '2', b: 'baz' }
+      {$key: '0', f: 'foo'}, {$key: '1', b: 'bar'}, {$key: '2', b: 'baz'}
     ]);
   });
 });

--- a/test/collection/uniq.spec.pipe.ts
+++ b/test/collection/uniq.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { UniqPipe } from '../../src/index';
+import {UniqPipe} from '../../src/index';
 
 describe('UniqPipe', () => {
   let pipe: UniqPipe;
@@ -6,28 +6,28 @@ describe('UniqPipe', () => {
     pipe = new UniqPipe();
   });
   it('should get a collection of primitives and return pipe.transformed collection', function() {
-    //Boolean
+    // Boolean
     expect(pipe.transform([true, true, false, false, true])).toEqual([true, false]);
-    //numbers
+    // numbers
     expect(pipe.transform([1, 1, 2, 3, 4, 5, 5, 5, 5])).toEqual([1, 2, 3, 4, 5]);
-    //strings
-    expect(pipe.transform(["Ariel", "Ariel", "Ariel"])).toEqual(["Ariel"]);
+    // strings
+    expect(pipe.transform(['Ariel', 'Ariel', 'Ariel'])).toEqual(['Ariel']);
   });
 
   it('should get array as collection, property(nested to) as identifier and filter', function() {
 
     var orders = [
-      { id: 10, customer: { name: 'foo', id: 1 } },
-      { id: 11, customer: { name: 'bar', id: 2 } },
-      { id: 12, customer: { name: 'foo', id: 1 } },
-      { id: 13, customer: { name: 'bar', id: 2 } },
-      { id: 14, customer: { name: 'baz', id: 3 } },
+      {id: 10, customer: {name: 'foo', id: 1}},
+      {id: 11, customer: {name: 'bar', id: 2}},
+      {id: 12, customer: {name: 'foo', id: 1}},
+      {id: 13, customer: {name: 'bar', id: 2}},
+      {id: 14, customer: {name: 'baz', id: 3}},
     ];
 
     var filteredOrders = [
-      { id: 10, customer: { name: 'foo', id: 1 } },
-      { id: 11, customer: { name: 'bar', id: 2 } },
-      { id: 14, customer: { name: 'baz', id: 3 } },
+      {id: 10, customer: {name: 'foo', id: 1}},
+      {id: 11, customer: {name: 'bar', id: 2}},
+      {id: 14, customer: {name: 'baz', id: 3}},
     ];
 
     expect(pipe.transform(orders, 'customer.id')).toEqual(filteredOrders);
@@ -44,31 +44,28 @@ describe('UniqPipe', () => {
   it('should filtered by property and not touch members without this property', function() {
 
     var array = [
-      { id: 1, person: { name: 'Ariel', age: 25 } },
-      { id: 2, person: { name: 'Joe', age: 25 } },
-      { id: 3, person: { name: 'Bob', age: 42 } },
-      { id: 4, person: { name: 'Marie', age: 42 } },
-      {}, [], 1, 2, 'foo', true, null
+      {id: 1, person: {name: 'Ariel', age: 25}}, {id: 2, person: {name: 'Joe', age: 25}},
+      {id: 3, person: {name: 'Bob', age: 42}}, {id: 4, person: {name: 'Marie', age: 42}}, {}, [], 1,
+      2, 'foo', true, null
     ];
 
     var filteredArray = [
-      { id: 1, person: { name: 'Ariel', age: 25 } },
-      { id: 3, person: { name: 'Bob', age: 42 } },
-      {}, [], 1, 2, 'foo', true, null
+      {id: 1, person: {name: 'Ariel', age: 25}}, {id: 3, person: {name: 'Bob', age: 42}}, {}, [], 1,
+      2, 'foo', true, null
     ];
 
-    //filter by person.age
+    // filter by person.age
     expect(pipe.transform(array, 'person.age')).toEqual(filteredArray);
 
-    //should not touch members without this property
+    // should not touch members without this property
     expect(pipe.transform(array, 'id')).toEqual(array);
   });
 
   it('should support advance nested properties', function() {
     var orders = [
-      { order: { person: { credit: { information: { num: 99999 } } } } },
-      { order: { person: { credit: { information: { num: 99999 } } } } },
-      { order: { person: { credit: { information: { num: 99999 } } } } }
+      {order: {person: {credit: {information: {num: 99999}}}}},
+      {order: {person: {credit: {information: {num: 99999}}}}},
+      {order: {person: {credit: {information: {num: 99999}}}}}
     ];
     expect(pipe.transform(orders, 'order.person.credit.information.num')).toEqual([orders[0]]);
   });

--- a/test/collection/where.spec.pipe.ts
+++ b/test/collection/where.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { WherePipe } from '../../src/index';
+import {WherePipe} from '../../src/index';
 
 describe('WherePipe', () => {
   let pipe: WherePipe;
@@ -7,35 +7,35 @@ describe('WherePipe', () => {
   });
 
   it('should get array and properties object and return' +
-    'array of all elements that have equivalent property values.', function() {
-      var array = [
-        { id: 0, name: 'ariel' },
-        { id: 1, name: 'baz' },
-        { id: 0, name: 'ariel' },
-        { id: 0, name: 'bar' }
-      ];
+         'array of all elements that have equivalent property values.',
+     function() {
+       var array = [
+         {id: 0, name: 'ariel'}, {id: 1, name: 'baz'}, {id: 0, name: 'ariel'},
+         {id: 0, name: 'bar'}
+       ];
 
-      expect(pipe.transform(array, { id: 0, name: 'ariel' })).toEqual([array[0], array[2]]);
-      expect(pipe.transform(array, { id: 0 })).not.toContain(array[1]);
-      expect(pipe.transform(array, {})).toEqual(array);
-    });
+       expect(pipe.transform(array, {id: 0, name: 'ariel'})).toEqual([array[0], array[2]]);
+       expect(pipe.transform(array, {id: 0})).not.toContain(array[1]);
+       expect(pipe.transform(array, {})).toEqual(array);
+     });
 
   it('should get object and properties object and return' +
-    'array of all elements that have equivalent property values.', function() {
-      var object = {
-        0: { id: 1, name: 'ariel' },
-        1: { id: 2, name: 'baz' },
-        2: { id: 1, name: 'ariel' },
-        3: { id: 1, name: 'bar' }
-      };
+         'array of all elements that have equivalent property values.',
+     function() {
+       var object = {
+         0: {id: 1, name: 'ariel'},
+         1: {id: 2, name: 'baz'},
+         2: {id: 1, name: 'ariel'},
+         3: {id: 1, name: 'bar'}
+       };
 
-      expect(pipe.transform(object, { id: 1, name: 'ariel' })).toEqual([object[0], object[2]]);
-      expect(pipe.transform(object, { id: 1 })).not.toContain(object[1]);
-      expect(pipe.transform(object, {}).length).toEqual(4);
-    });
+       expect(pipe.transform(object, {id: 1, name: 'ariel'})).toEqual([object[0], object[2]]);
+       expect(pipe.transform(object, {id: 1})).not.toContain(object[1]);
+       expect(pipe.transform(object, {}).length).toEqual(4);
+     });
 
   it('should not get properties object and return the collection as is', function() {
-    expect(pipe.transform([{ a: 1 }])).toEqual([{ a: 1 }]);
-    expect(pipe.transform([{ a: 1 }, { b: 2 }])).toEqual([{ a: 1 }, { b: 2 }]);
+    expect(pipe.transform([{a: 1}])).toEqual([{a: 1}]);
+    expect(pipe.transform([{a: 1}, {b: 2}])).toEqual([{a: 1}, {b: 2}]);
   });
 });

--- a/test/collection/xor.spec.pipe.ts
+++ b/test/collection/xor.spec.pipe.ts
@@ -1,11 +1,10 @@
-import { XORPipe } from '../../src/index';
+import {XORPipe} from '../../src/index';
 
 describe('XORPipe', () => {
   let pipe: XORPipe;
   beforeEach(() => {
     pipe = new XORPipe();
   });
-
 
   it('should get 2 array collection and return exclusive or between them', function() {
     expect(pipe.transform([1, 2], [1])).toEqual([2]);
@@ -16,35 +15,28 @@ describe('XORPipe', () => {
   });
 
   it('should get objects as collection', function() {
-    expect(pipe.transform({ 0: 1, 1: 2 }, { 0: 3 })).toEqual([1, 2, 3]);
-    expect(pipe.transform({ 0: 1, 1: 2 }, { 0: 1 })).toEqual([2]);
+    expect(pipe.transform({0: 1, 1: 2}, {0: 3})).toEqual([1, 2, 3]);
+    expect(pipe.transform({0: 1, 1: 2}, {0: 1})).toEqual([2]);
   });
 
   it('should get an objects collection and filters by value', function() {
-    var array = [
-      { id: 1, name: 'foo' },
-      { id: 2, name: 'bar' },
-      { id: 3, name: 'baz' }
-    ];
+    var array = [{id: 1, name: 'foo'}, {id: 2, name: 'bar'}, {id: 3, name: 'baz'}];
 
-    expect(pipe.transform(array, array)).toEqual([]); // A (xor) A
+    expect(pipe.transform(array, array)).toEqual([]);  // A (xor) A
   });
-
 
   it('should filter by specific property', function() {
     var users = [
-      { id: 0, details: { first_name: 'foo', last_name: 'bar' } },
-      { id: 1, details: { first_name: 'foo', last_name: 'baz' } },
-      { id: 2, details: { first_name: 'foo', last_name: 'bag' } }
+      {id: 0, details: {first_name: 'foo', last_name: 'bar'}},
+      {id: 1, details: {first_name: 'foo', last_name: 'baz'}},
+      {id: 2, details: {first_name: 'foo', last_name: 'bag'}}
     ];
 
-    expect(pipe.transform(users, [{ details: { first_name: 'foo' } }], 'details.first_name'))
-      .toEqual([]);
-    expect(pipe.transform(users, [{ id: 0 }, { id: 1 }], 'id')).toEqual([users[2]]);
+    expect(pipe.transform(users, [{details: {first_name: 'foo'}}], 'details.first_name')).toEqual([
+    ]);
+    expect(pipe.transform(users, [{id: 0}, {id: 1}], 'id')).toEqual([users[2]]);
 
-    expect(pipe.transform(users, [{ id: 3, details: { first_name: 'foo', last_name: 'bag' } }], 'id'))
-      .toEqual(
-      users.concat([{ id: 3, details: { first_name: 'foo', last_name: 'bag' } }]
-      ));
+    expect(pipe.transform(users, [{id: 3, details: {first_name: 'foo', last_name: 'bag'}}], 'id'))
+        .toEqual(users.concat([{id: 3, details: {first_name: 'foo', last_name: 'bag'}}]));
   });
 });

--- a/test/math/abs.spec.pipe.ts
+++ b/test/math/abs.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { AbsPipe } from '../../src/index';
+import {AbsPipe} from '../../src/index';
 
 describe('AbsPipe', () => {
   let pipe: AbsPipe;

--- a/test/math/byte-fmt.spec.pipe.ts
+++ b/test/math/byte-fmt.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { ByteFmtPipe } from '../../src/index';
+import {ByteFmtPipe} from '../../src/index';
 
 describe('ByteFmtPipe', () => {
   let pipe: ByteFmtPipe;
@@ -7,29 +7,27 @@ describe('ByteFmtPipe', () => {
   });
 
   it('should return the correct display from number of bytes', function() {
-    expect(pipe.transform(0, 2)).toEqual("0 B");
-    expect(pipe.transform(5, 2)).toEqual("5 B");
-    expect(pipe.transform(1024, 0)).toEqual("1 KB");
-    expect(pipe.transform(1998, 2)).toEqual("1.95 KB");
-    expect(pipe.transform(1049901, 5)).toEqual("1.00126 MB");
-    expect(pipe.transform(909234901, 1)).toEqual("867.1 MB");
-    expect(pipe.transform(1339234901, 5)).toEqual("1.24726 GB");
-    expect(pipe.transform(23423234234, 2)).toEqual("21.81 GB");
-    expect(pipe.transform(23985391855616, 2)).toEqual("21.81 TB");
-    expect(pipe.transform(95340189555097611, 1)).toEqual("84.7 PB");
-    expect(pipe.transform(2249548013871562752, 3)).toEqual("1.951 EB");
-    expect(pipe.transform(5180591620717411303425, 2)).toEqual("4.39 ZB");
-    expect(pipe.transform(5123980591620717411303425, 2)).toEqual("4.24 YB");
+    expect(pipe.transform(0, 2)).toEqual('0 B');
+    expect(pipe.transform(5, 2)).toEqual('5 B');
+    expect(pipe.transform(1024, 0)).toEqual('1 KB');
+    expect(pipe.transform(1998, 2)).toEqual('1.95 KB');
+    expect(pipe.transform(1049901, 5)).toEqual('1.00126 MB');
+    expect(pipe.transform(909234901, 1)).toEqual('867.1 MB');
+    expect(pipe.transform(1339234901, 5)).toEqual('1.24726 GB');
+    expect(pipe.transform(23423234234, 2)).toEqual('21.81 GB');
+    expect(pipe.transform(23985391855616, 2)).toEqual('21.81 TB');
+    expect(pipe.transform(95340189555097611, 1)).toEqual('84.7 PB');
+    expect(pipe.transform(2249548013871562752, 3)).toEqual('1.951 EB');
+    expect(pipe.transform(5180591620717411303425, 2)).toEqual('4.39 ZB');
+    expect(pipe.transform(5123980591620717411303425, 2)).toEqual('4.24 YB');
   });
 
-
-
   it('should return NaN if decimal point is less than zero or not a number', function() {
-    expect(pipe.transform(0.45, -1)).toEqual("NaN");
-    expect(pipe.transform(-0.25, -101)).toEqual("NaN");
-    expect(pipe.transform(0.45, 1.3)).toEqual("NaN");
-    expect(pipe.transform(0.45, "0")).toEqual("NaN");
-    expect(pipe.transform(0.45, [3])).toEqual("NaN");
-    expect(pipe.transform(0.45, { num: 4 })).toEqual("NaN");
+    expect(pipe.transform(0.45, -1)).toEqual('NaN');
+    expect(pipe.transform(-0.25, -101)).toEqual('NaN');
+    expect(pipe.transform(0.45, 1.3)).toEqual('NaN');
+    expect(pipe.transform(0.45, '0')).toEqual('NaN');
+    expect(pipe.transform(0.45, [3])).toEqual('NaN');
+    expect(pipe.transform(0.45, {num: 4})).toEqual('NaN');
   });
 });

--- a/test/math/degrees.spec.pipe.ts
+++ b/test/math/degrees.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { DegreesPipe } from '../../src/index';
+import {DegreesPipe} from '../../src/index';
 
 describe('DegreesPipe', () => {
   let pipe: DegreesPipe;

--- a/test/math/kb-fmt.spec.pipe.ts
+++ b/test/math/kb-fmt.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { KBFmtPipe } from '../../src/index';
+import {KBFmtPipe} from '../../src/index';
 
 describe('KBFmtPipe', () => {
   let pipe: KBFmtPipe;
@@ -7,28 +7,27 @@ describe('KBFmtPipe', () => {
   });
 
   it('should return the correct display from number of kilobytes', function() {
-    expect(pipe.transform(0, 2)).toEqual("0 KB");
-    expect(pipe.transform(5, 2)).toEqual("5 KB");
-    expect(pipe.transform(1024, 0)).toEqual("1 MB");
-    expect(pipe.transform(1998, 2)).toEqual("1.95 MB");
-    expect(pipe.transform(1049901, 5)).toEqual("1.00126 GB");
-    expect(pipe.transform(909234901, 1)).toEqual("867.1 GB");
-    expect(pipe.transform(1339234901, 5)).toEqual("1.24726 TB");
-    expect(pipe.transform(23423234234, 2)).toEqual("21.81 TB");
-    expect(pipe.transform(23985391855616, 2)).toEqual("21.81 PB");
-    expect(pipe.transform(95340189555097611, 1)).toEqual("84.7 EB");
-    expect(pipe.transform(2249548013871562752, 3)).toEqual("1.951 ZB");
-    expect(pipe.transform(5180591620717411303425, 2)).toEqual("4.39 YB");
-    expect(pipe.transform(5123980591620717411303425, 2)).toEqual("4340.18 YB");
+    expect(pipe.transform(0, 2)).toEqual('0 KB');
+    expect(pipe.transform(5, 2)).toEqual('5 KB');
+    expect(pipe.transform(1024, 0)).toEqual('1 MB');
+    expect(pipe.transform(1998, 2)).toEqual('1.95 MB');
+    expect(pipe.transform(1049901, 5)).toEqual('1.00126 GB');
+    expect(pipe.transform(909234901, 1)).toEqual('867.1 GB');
+    expect(pipe.transform(1339234901, 5)).toEqual('1.24726 TB');
+    expect(pipe.transform(23423234234, 2)).toEqual('21.81 TB');
+    expect(pipe.transform(23985391855616, 2)).toEqual('21.81 PB');
+    expect(pipe.transform(95340189555097611, 1)).toEqual('84.7 EB');
+    expect(pipe.transform(2249548013871562752, 3)).toEqual('1.951 ZB');
+    expect(pipe.transform(5180591620717411303425, 2)).toEqual('4.39 YB');
+    expect(pipe.transform(5123980591620717411303425, 2)).toEqual('4340.18 YB');
   });
 
-
   it('should return NaN if decimal point is less than zero or not a number', function() {
-    expect(pipe.transform(0.45, -1)).toEqual("NaN");
-    expect(pipe.transform(-0.25, -101)).toEqual("NaN");
-    expect(pipe.transform(0.45, 1.3)).toEqual("NaN");
-    expect(pipe.transform(0.45, "0")).toEqual("NaN");
-    expect(pipe.transform(0.45, [3])).toEqual("NaN");
-    expect(pipe.transform(0.45, { num: 4 })).toEqual("NaN");
+    expect(pipe.transform(0.45, -1)).toEqual('NaN');
+    expect(pipe.transform(-0.25, -101)).toEqual('NaN');
+    expect(pipe.transform(0.45, 1.3)).toEqual('NaN');
+    expect(pipe.transform(0.45, '0')).toEqual('NaN');
+    expect(pipe.transform(0.45, [3])).toEqual('NaN');
+    expect(pipe.transform(0.45, {num: 4})).toEqual('NaN');
   });
 });

--- a/test/math/max.spec.pipe.ts
+++ b/test/math/max.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { MaxPipe } from '../../src/index';
+import {MaxPipe} from '../../src/index';
 
 describe('MaxPipe', () => {
   let pipe: MaxPipe;
@@ -14,10 +14,8 @@ describe('MaxPipe', () => {
 
   it('should get an array and expression and return an object', function() {
     var users = [
-      { user: { score: 988790 } },
-      { user: { score: 123414 } },
-      { user: { rank: 988999 } },
-      { user: { score: 987621 } }
+      {user: {score: 988790}}, {user: {score: 123414}}, {user: {rank: 988999}},
+      {user: {score: 987621}}
     ];
     expect(pipe.transform(users, 'user.rank')).toEqual(users[2]);
     expect(pipe.transform(users, 'user.score')).toEqual(users[0]);

--- a/test/math/min.spec.pipe.ts
+++ b/test/math/min.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { MinPipe } from '../../src/index';
+import {MinPipe} from '../../src/index';
 
 describe('MinPipe', () => {
   let pipe: MinPipe;
@@ -14,10 +14,8 @@ describe('MinPipe', () => {
 
   it('should get an array and expression and return an object', function() {
     var users = [
-      { user: { score: 988790 } },
-      { user: { score: 123414 } },
-      { user: { rank: 100000 } },
-      { user: { score: 987621 } }
+      {user: {score: 988790}}, {user: {score: 123414}}, {user: {rank: 100000}},
+      {user: {score: 987621}}
     ];
     expect(pipe.transform(users, 'user.rank')).toEqual(users[2]);
     expect(pipe.transform(users, 'user.score')).toEqual(users[1]);

--- a/test/math/percent.spec.pipe.ts
+++ b/test/math/percent.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { PercentPipe } from '../../src/index';
+import {PercentPipe} from '../../src/index';
 
 describe('PercentPipe', () => {
   let pipe: PercentPipe;

--- a/test/math/radians.spec.pipe.ts
+++ b/test/math/radians.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { RadiansPipe } from '../../src/index';
+import {RadiansPipe} from '../../src/index';
 
 describe('RadiansPipe', () => {
   let pipe: RadiansPipe;

--- a/test/math/radix.spec.pipe.ts
+++ b/test/math/radix.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { RadixPipe } from '../../src/index';
+import {RadixPipe} from '../../src/index';
 
 describe('RadixPipe', () => {
   let pipe: RadixPipe;

--- a/test/math/short-fmt.spec.pipe.ts
+++ b/test/math/short-fmt.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { ShortFmtPipe } from '../../src/index';
+import {ShortFmtPipe} from '../../src/index';
 
 describe('ShortFmtPipe', () => {
   let pipe: ShortFmtPipe;
@@ -9,10 +9,10 @@ describe('ShortFmtPipe', () => {
   it('should return the correct display from the number', function() {
     expect(pipe.transform(0, 2)).toEqual('0');
     expect(pipe.transform(5, 2)).toEqual('5');
-    expect(pipe.transform(1024, 0)).toEqual("1 K");
-    expect(pipe.transform(1993, 2)).toEqual("1.99 K");
-    expect(pipe.transform(1049901, 5)).toEqual("1.0499 M");
-    expect(pipe.transform(1909234901, 2)).toEqual("1.91 B");
+    expect(pipe.transform(1024, 0)).toEqual('1 K');
+    expect(pipe.transform(1993, 2)).toEqual('1.99 K');
+    expect(pipe.transform(1049901, 5)).toEqual('1.0499 M');
+    expect(pipe.transform(1909234901, 2)).toEqual('1.91 B');
 
   });
 });

--- a/test/math/sum.spec.pipe.ts
+++ b/test/math/sum.spec.pipe.ts
@@ -1,4 +1,4 @@
-import { SumPipe } from '../../src/index';
+import {SumPipe} from '../../src/index';
 
 describe('SumPipe', () => {
   let pipe: SumPipe;

--- a/test/string/ends-with.pipe.spec.ts
+++ b/test/string/ends-with.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { EndsWithPipe } from '../../src/index';
+import {EndsWithPipe} from '../../src/index';
 
 describe('EndsWithPipe', () => {
   let pipe: EndsWithPipe;

--- a/test/string/latinize.pipe.spec.ts
+++ b/test/string/latinize.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { LatinizePipe } from '../../src/index';
+import {LatinizePipe} from '../../src/index';
 
 describe('LatinizePipe', () => {
   let pipe: LatinizePipe;

--- a/test/string/ltrim.pipe.spec.ts
+++ b/test/string/ltrim.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { LeftTrimPipe } from '../../src/index';
+import {LeftTrimPipe} from '../../src/index';
 
 describe('LeftTrimPipe', () => {
   let pipe: LeftTrimPipe;

--- a/test/string/match.pipe.spec.ts
+++ b/test/string/match.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { MatchPipe } from '../../src/index';
+import {MatchPipe} from '../../src/index';
 
 describe('MatchPipe', () => {
   let pipe: MatchPipe;

--- a/test/string/repeat.pipe.spec.ts
+++ b/test/string/repeat.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { RepeatPipe } from '../../src/index';
+import {RepeatPipe} from '../../src/index';
 
 describe('RepeatPipe', () => {
   let pipe: RepeatPipe;

--- a/test/string/rtrim.pipe.spec.ts
+++ b/test/string/rtrim.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { RightTrimPipe } from '../../src/index';
+import {RightTrimPipe} from '../../src/index';
 
 describe('RightTrimPipe', () => {
   let pipe: RightTrimPipe;

--- a/test/string/slugify.pipe.spec.ts
+++ b/test/string/slugify.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { SlugifyPipe } from '../../src/index';
+import {SlugifyPipe} from '../../src/index';
 
 describe('SlugifyPipe', () => {
   let pipe: SlugifyPipe;

--- a/test/string/starts-with.pipe.spec.ts
+++ b/test/string/starts-with.pipe.spec.ts
@@ -1,5 +1,4 @@
-import { StartsWithPipe } from '../../src/index';
-
+import {StartsWithPipe} from '../../src/index';
 
 describe('StartsWithPipe', () => {
   let pipe: StartsWithPipe;

--- a/test/string/stringular.pipe.spec.ts
+++ b/test/string/stringular.pipe.spec.ts
@@ -1,5 +1,4 @@
-import { StringularPipe } from '../../src/index';
-
+import {StringularPipe} from '../../src/index';
 
 describe('StringularPipe', () => {
   let pipe: StringularPipe;
@@ -12,13 +11,17 @@ describe('StringularPipe', () => {
   });
 
   it('should replace {n} with arguments passed after the text argument', function() {
-    expect(pipe.transform('lorem {0} dolor sit amet', 'ipsum')).toEqual('lorem ipsum dolor sit amet');
-    expect(pipe.transform('lorem {0} dolor {1} amet', 'ipsum', 'sit')).toEqual('lorem ipsum dolor sit amet');
-    expect(pipe.transform('{3} {0} dolor {1} amet', 'ipsum', 'sit', null, 'lorem')).toEqual('lorem ipsum dolor sit amet');
+    expect(pipe.transform('lorem {0} dolor sit amet', 'ipsum'))
+        .toEqual('lorem ipsum dolor sit amet');
+    expect(pipe.transform('lorem {0} dolor {1} amet', 'ipsum', 'sit'))
+        .toEqual('lorem ipsum dolor sit amet');
+    expect(pipe.transform('{3} {0} dolor {1} amet', 'ipsum', 'sit', null, 'lorem'))
+        .toEqual('lorem ipsum dolor sit amet');
   });
 
   it('should keep {n} if no matching argument was found', function() {
     expect(pipe.transform('lorem {0} dolor sit amet')).toEqual('lorem {0} dolor sit amet');
-    expect(pipe.transform('lorem {0} dolor {1} amet', 'ipsum')).toEqual('lorem ipsum dolor {1} amet');
+    expect(pipe.transform('lorem {0} dolor {1} amet', 'ipsum'))
+        .toEqual('lorem ipsum dolor {1} amet');
   });
 });

--- a/test/string/strip-tags.pipe.spec.ts
+++ b/test/string/strip-tags.pipe.spec.ts
@@ -1,5 +1,4 @@
-import { StripTagsPipe } from '../../src/index';
-
+import {StripTagsPipe} from '../../src/index';
 
 describe('EndsWithPipe', () => {
   let pipe: StripTagsPipe;

--- a/test/string/test.pipe.spec.ts
+++ b/test/string/test.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { TestPipe } from '../../src/index';
+import {TestPipe} from '../../src/index';
 
 describe('TestPipe', () => {
   let pipe: TestPipe;
@@ -7,12 +7,14 @@ describe('TestPipe', () => {
   });
 
   it('should test a string with given pattern', function() {
-    expect(pipe.transform('15/12/2003', '^[0-9]{2}[/]{1}[0-9]{2}[/]{1}[0-9]{4}$', 'i')).toEqual(true);
+    expect(pipe.transform('15/12/2003', '^[0-9]{2}[/]{1}[0-9]{2}[/]{1}[0-9]{4}$', 'i'))
+        .toEqual(true);
     expect(pipe.transform('foobarbaz', '^[a-z]{3,}$')).toEqual(true);
     expect(pipe.transform('FOOBARBAZ', '^[a-z]{3,}$', 'i')).toEqual(true);
     expect(pipe.transform('FOOBARBAZ', '^[a-z]{3,}$')).toEqual(false);
     expect(pipe.transform('foobarbaz', '\\W')).toEqual(false);
     expect(pipe.transform('foobarbaz', '\\w')).toEqual(true);
-    expect(pipe.transform('1a/bb/2003', '^[0-9]{2}[/]{1}[0-9]{2}[/]{1}[0-9]{4}$', 'i')).toEqual(false);
+    expect(pipe.transform('1a/bb/2003', '^[0-9]{2}[/]{1}[0-9]{2}[/]{1}[0-9]{4}$', 'i'))
+        .toEqual(false);
   });
 });

--- a/test/string/titleize.pipe.spec.ts
+++ b/test/string/titleize.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { TitleizePipe } from '../../src/index';
+import {TitleizePipe} from '../../src/index';
 
 describe('TitleizePipe', () => {
   let pipe: TitleizePipe;
@@ -10,6 +10,6 @@ describe('TitleizePipe', () => {
     expect(pipe.transform('a')).toEqual('A');
     expect(pipe.transform('foo bar baz')).toEqual('Foo Bar Baz');
     expect(pipe.transform('lorem ipsum is simply dummy.... industry.'))
-      .toEqual('Lorem Ipsum Is Simply Dummy.... Industry.');
+        .toEqual('Lorem Ipsum Is Simply Dummy.... Industry.');
   });
 });

--- a/test/string/trim.pipe.spec.ts
+++ b/test/string/trim.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { TrimPipe } from '../../src/index';
+import {TrimPipe} from '../../src/index';
 
 describe('TrimPipe', () => {
   let pipe: TrimPipe;

--- a/test/string/truncate.pipe.spec.ts
+++ b/test/string/truncate.pipe.spec.ts
@@ -1,5 +1,4 @@
-import { TruncatePipe } from '../../src/index';
-
+import {TruncatePipe} from '../../src/index';
 
 describe('TruncatePipe', () => {
   let pipe: TruncatePipe;
@@ -10,7 +9,8 @@ describe('TruncatePipe', () => {
   it('should cut a string if it is longer than the provided length', () => {
     expect(pipe.transform('lorem ipsum dolor sit amet', 5, '', false)).toEqual('lorem');
     expect(pipe.transform('lorem ipsum dolor sit amet', 11, '', false)).toEqual('lorem ipsum');
-    expect(pipe.transform('lorem ipsum dolor sit amet', 50, '', false)).toEqual('lorem ipsum dolor sit amet');
+    expect(pipe.transform('lorem ipsum dolor sit amet', 50, '', false))
+        .toEqual('lorem ipsum dolor sit amet');
 
     expect(pipe.transform('abcdef', 3, '', false)).toEqual('abc');
     expect(pipe.transform('abcd ef', 6, '', false)).toEqual('abcd e');
@@ -19,7 +19,8 @@ describe('TruncatePipe', () => {
   it('should not cut words in the middle if preserve is true', () => {
     expect(pipe.transform('lorem ipsum dolor sit amet', 7, '', true)).toEqual('lorem ipsum');
     expect(pipe.transform('lorem ipsum dolor sit amet', 13, '', true)).toEqual('lorem ipsum dolor');
-    expect(pipe.transform('lorem ipsum dolor sit amet', 50, '', true)).toEqual('lorem ipsum dolor sit amet');
+    expect(pipe.transform('lorem ipsum dolor sit amet', 50, '', true))
+        .toEqual('lorem ipsum dolor sit amet');
 
     expect(pipe.transform('abcdef', 3, '', true)).toEqual('abcdef');
     expect(pipe.transform('abcd ef', 6, '', true)).toEqual('abcd ef');
@@ -27,7 +28,9 @@ describe('TruncatePipe', () => {
 
   it('should append the provided prefix if a string has been cut', () => {
     expect(pipe.transform('lorem ipsum dolor sit amet', 7, '...', true)).toEqual('lorem ipsum...');
-    expect(pipe.transform('lorem ipsum dolor sit amet', 13, '...', true)).toEqual('lorem ipsum dolor...');
-    expect(pipe.transform('lorem ipsum dolor sit amet', 50, '...', true)).toEqual('lorem ipsum dolor sit amet');
+    expect(pipe.transform('lorem ipsum dolor sit amet', 13, '...', true))
+        .toEqual('lorem ipsum dolor...');
+    expect(pipe.transform('lorem ipsum dolor sit amet', 50, '...', true))
+        .toEqual('lorem ipsum dolor sit amet');
   });
 });

--- a/test/string/ucfirst.pipe.spec.ts
+++ b/test/string/ucfirst.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { UcfirstPipe } from '../../src/index';
+import {UcfirstPipe} from '../../src/index';
 
 describe('UcfirstPipe', () => {
   let pipe: UcfirstPipe;
@@ -10,6 +10,6 @@ describe('UcfirstPipe', () => {
     expect(pipe.transform('a')).toEqual('A');
     expect(pipe.transform('foo bar baz')).toEqual('Foo bar baz');
     expect(pipe.transform('lorem ipsum is simply dummy.... industry.'))
-      .toEqual('Lorem ipsum is simply dummy.... industry.');
+        .toEqual('Lorem ipsum is simply dummy.... industry.');
   });
 });

--- a/test/string/wrap.pipe.spec.ts
+++ b/test/string/wrap.pipe.spec.ts
@@ -1,5 +1,4 @@
-import { WrapPipe } from '../../src/index';
-
+import {WrapPipe} from '../../src/index';
 
 describe('WrapPipe', () => {
   let pipe: WrapPipe;


### PR DESCRIPTION
[clang-format](http://clang.llvm.org/docs/ClangFormat.html) formats code to comply to the [Google JavaScript style guide](https://google.github.io/styleguide/javascriptguide.xml).

Plugins for formatting-on-save are available for [Atom](https://atom.io/packages/clang-format) and [vscode](https://marketplace.visualstudio.com/items?itemName=xaver.clang-format) (probably for others too).
